### PR TITLE
feat: dynamic post discovery via import.meta.glob

### DIFF
--- a/src/pages/architecture/index.astro
+++ b/src/pages/architecture/index.astro
@@ -1,26 +1,25 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 
-const essays = [
-  {
-    href: "/architecture/nic-operator-platform-wiring/",
-    tag: "operator design",
-    title: "Designing the NIC operator as a platform wiring layer",
-    desc: "A Kubernetes-native contract for route, TLS, and auth attachment in a GitOps platform ecosystem.",
-  },
-  {
-    href: "/architecture/keycloak-state-recreation/",
-    tag: "state systems",
-    title: "Backup and restore as declarative state recreation",
-    desc: "Dependency ordering, dry-run planning, conflict handling, and import/export boundaries.",
-  },
-  {
-    href: "/architecture/distance-geometry-protein-refinement/",
-    tag: "computational geometry",
-    title: "Protein conformation as a distance geometry problem",
-    desc: "SDP relaxation as initial point, spectral projected gradient as refinement — recovering 3D structure from sparse distance bounds.",
-  },
-];
+interface PostMeta {
+  title: string;
+  date?: string;
+  tag: string;
+  description: string;
+}
+interface PostModule { metadata?: PostMeta; }
+
+function toHref(base: string, path: string) {
+  return base + path.replace(/^\.\//, '/').replace(/\/index\.(astro|mdx)$/, '/');
+}
+
+const astroModules = import.meta.glob<PostModule>('./*/index.astro', { eager: true });
+const mdxModules  = import.meta.glob<PostModule>('./*/index.mdx',   { eager: true });
+
+const essays = [...Object.entries(astroModules), ...Object.entries(mdxModules)]
+  .filter(([, m]) => m.metadata)
+  .map(([path, m]) => ({ href: toHref('/architecture', path), ...m.metadata! }))
+  .sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''));
 ---
 
 <Layout title="Architecture — Vinicius Cerutti" description="Long-form design notes about system boundaries, tradeoffs, and platform direction.">
@@ -32,15 +31,19 @@ const essays = [
       </header>
 
       <section class="py-[clamp(36px,4vw,52px)]">
-        <div class="grid grid-cols-2 gap-3.5">
-          {essays.map(({ href, tag, title, desc }) => (
-            <a href={href} class="index-card">
-              <div class="card-tag">{tag}</div>
-              <h2 class="card-title">{title}</h2>
-              <p class="card-desc">{desc}</p>
-            </a>
-          ))}
-        </div>
+        {essays.length === 0 ? (
+          <p class="text-muted-foreground text-sm">No essays published yet.</p>
+        ) : (
+          <div class="grid grid-cols-2 gap-3.5">
+            {essays.map(({ href, tag, title, description }) => (
+              <a href={href} class="index-card">
+                <div class="card-tag">{tag}</div>
+                <h2 class="card-title">{title}</h2>
+                <p class="card-desc">{description}</p>
+              </a>
+            ))}
+          </div>
+        )}
       </section>
     </main>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,29 +1,32 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 
-const latestNotes = [
-  {
-    href: "/notes/nvidia-runtimeclass-gpu-workloads/",
-    date: "2026-04-11",
-    tag: "debugging",
-    title: "Injecting NVIDIA runtimeClass into GPU workloads",
-    desc: "Device plugin, nvidia-ctk, containerd config, RuntimeClass, and Kyverno policy boundaries.",
-  },
-  {
-    href: "/notes/traefik-tls-options-scanner-expectations/",
-    date: "2026-04-07",
-    tag: "security",
-    title: "Traefik TLS options and scanner expectations",
-    desc: "Ingress behavior, TLS 1.2 cipher policy, redirects, and certificate chain presentation.",
-  },
-  {
-    href: "/architecture/keycloak-state-recreation/",
-    date: "2026-03-28",
-    tag: "architecture",
-    title: "Keycloak state recreation without surprises",
-    desc: "Dependency ordering, dry-run planning, conflict handling, and import/export boundaries.",
-  },
-];
+interface PostMeta {
+  title: string;
+  date?: string;
+  tag: string;
+  description: string;
+}
+interface PostModule { metadata?: PostMeta; }
+
+function toHref(base: string, path: string) {
+  return base + path.replace(/^\.\/[^/]+/, '').replace(/\/index\.(astro|mdx)$/, '/');
+}
+
+const noteAstro = import.meta.glob<PostModule>('./notes/*/index.astro', { eager: true });
+const noteMdx   = import.meta.glob<PostModule>('./notes/*/index.mdx',   { eager: true });
+const archAstro = import.meta.glob<PostModule>('./architecture/*/index.astro', { eager: true });
+const archMdx   = import.meta.glob<PostModule>('./architecture/*/index.mdx',   { eager: true });
+
+const allRecent = [
+  ...Object.entries({ ...noteAstro, ...noteMdx }).map(([p, m]) => ({ href: toHref('/notes', p), ...m.metadata! })),
+  ...Object.entries({ ...archAstro, ...archMdx }).map(([p, m]) => ({ href: toHref('/architecture', p), ...m.metadata! })),
+]
+  .filter(p => p.title && p.date)
+  .sort((a, b) => b.date!.localeCompare(a.date!));
+
+const featured = allRecent[0];
+const latestNotes = allRecent.slice(1, 4);
 ---
 
 <Layout title="Vinicius Cerutti — Field Notes">
@@ -62,31 +65,31 @@ const latestNotes = [
       </header>
 
       <!-- Latest -->
-      <section class="section-pad" aria-labelledby="latest-title">
-        <h2 class="section-kicker" id="latest-title">recent</h2>
+      {allRecent.length > 0 && (
+        <section class="section-pad" aria-labelledby="latest-title">
+          <h2 class="section-kicker" id="latest-title">recent</h2>
 
-        <div class="latest-layout">
-          <a href="/notes/k3s-tls-trust-errors/" class="featured-note card-link">
-            <div class="meta-label">2026-04-27 · field note</div>
-            <div>
-              <h3 class="featured-title text-foreground">K3s TLS trust errors from worker nodes</h3>
-              <p class="text-muted-foreground mb-0">
-                Why kubectl fails against the API server when kubeconfig ownership, CA data, or KUBECONFIG env drift.
-              </p>
+          <div class="latest-layout">
+            <a href={featured.href} class="featured-note card-link">
+              <div class="meta-label">{featured.date} · {featured.tag}</div>
+              <div>
+                <h3 class="featured-title text-foreground">{featured.title}</h3>
+                <p class="text-muted-foreground mb-0">{featured.description}</p>
+              </div>
+            </a>
+
+            <div class="note-list">
+              {latestNotes.map(({ href, date, tag, title, description }) => (
+                <a href={href} class="note-row block py-5 transition-all duration-150">
+                  <div class="meta-label mb-2">{date} · {tag}</div>
+                  <h3 class="text-[19px] font-semibold leading-snug tracking-tight text-foreground mb-1.5">{title}</h3>
+                  <p class="text-muted-foreground text-sm mb-0">{description}</p>
+                </a>
+              ))}
             </div>
-          </a>
-
-          <div class="note-list">
-            {latestNotes.map(({ href, date, tag, title, desc }) => (
-              <a href={href} class="note-row block py-5 transition-all duration-150">
-                <div class="meta-label mb-2">{date} · {tag}</div>
-                <h3 class="text-[19px] font-semibold leading-snug tracking-tight text-foreground mb-1.5">{title}</h3>
-                <p class="text-muted-foreground text-sm mb-0">{desc}</p>
-              </a>
-            ))}
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
     </main>
   </div>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -1,36 +1,25 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 
-const notes = [
-  {
-    href: "/notes/k3s-tls-trust-errors/",
-    date: "2026-04-27",
-    tag: "field note",
-    title: "K3s TLS trust errors from worker nodes",
-    desc: "Diagnosing kubeconfig, CA data, permissions, and API-server trust issues.",
-  },
-  {
-    href: "/notes/nvidia-runtimeclass-gpu-workloads/",
-    date: "2026-04-11",
-    tag: "debugging",
-    title: "Injecting NVIDIA runtimeClass into GPU workloads",
-    desc: "Device plugin, nvidia-ctk, containerd, RuntimeClass, and Kyverno policy boundaries.",
-  },
-  {
-    href: "/notes/traefik-tls-options-scanner-expectations/",
-    date: "2026-04-07",
-    tag: "security",
-    title: "Traefik TLS options and scanner expectations",
-    desc: "How TLS policy, redirect behavior, response headers, and certificate chains interact.",
-  },
-  {
-    href: "/notes/conda-forge-version-microservice/",
-    date: "2020-05-18",
-    tag: "gsoc",
-    title: "Separating conda-forge version updates from the graph",
-    desc: "Why update_upstream_versions needed to move out of the graph, and what extracting it actually involved.",
-  },
-];
+interface PostMeta {
+  title: string;
+  date: string;
+  tag: string;
+  description: string;
+}
+interface PostModule { metadata?: PostMeta; }
+
+function toHref(base: string, path: string) {
+  return base + path.replace(/^\.\//, '/').replace(/\/index\.(astro|mdx)$/, '/');
+}
+
+const astroModules = import.meta.glob<PostModule>('./*/index.astro', { eager: true });
+const mdxModules  = import.meta.glob<PostModule>('./*/index.mdx',   { eager: true });
+
+const notes = [...Object.entries(astroModules), ...Object.entries(mdxModules)]
+  .filter(([, m]) => m.metadata)
+  .map(([path, m]) => ({ href: toHref('/notes', path), ...m.metadata! }))
+  .sort((a, b) => b.date.localeCompare(a.date));
 ---
 
 <Layout title="Notes — Vinicius Cerutti" description="Field notes from real infrastructure work.">
@@ -44,15 +33,19 @@ const notes = [
       </header>
 
       <section class="py-[clamp(36px,4vw,52px)]">
-        <div class="grid grid-cols-2 gap-3.5">
-          {notes.map(({ href, date, tag, title, desc }) => (
-            <a href={href} class="index-card">
-              <div class="meta-label">{date} · {tag}</div>
-              <h2 class="index-title text-foreground">{title}</h2>
-              <p class="text-muted-foreground text-sm mb-0">{desc}</p>
-            </a>
-          ))}
-        </div>
+        {notes.length === 0 ? (
+          <p class="text-muted-foreground text-sm">No notes published yet.</p>
+        ) : (
+          <div class="grid grid-cols-2 gap-3.5">
+            {notes.map(({ href, date, tag, title, description }) => (
+              <a href={href} class="index-card">
+                <div class="meta-label">{date} · {tag}</div>
+                <h2 class="index-title text-foreground">{title}</h2>
+                <p class="text-muted-foreground text-sm mb-0">{description}</p>
+              </a>
+            ))}
+          </div>
+        )}
       </section>
     </main>
   </div>

--- a/src/templates/architecture.astro
+++ b/src/templates/architecture.astro
@@ -5,18 +5,25 @@
 //
 // Checklist before publishing:
 //   [ ] Title frames the decision, not just the component ("X as Y" or "Why we shaped X this way")
-//   [ ] Subtitle describes what the essay argues or explains
-//   [ ] Meta tag matches the area: operator design · state systems · platform · reliability
+//   [ ] metadata.description describes what the essay argues or explains
+//   [ ] metadata.tag matches the area: operator design · state systems · platform · reliability
 //   [ ] Sections flow: context → constraint → decision → tradeoffs
 //   [ ] No placeholder text remains
+
+export const metadata = {
+  title: "The decision or system being described",
+  date: "YYYY-MM-DD",
+  tag: "architecture",
+  description: "What this essay argues or explains — one sentence.",
+};
 
 import ArticleLayout from "@/layouts/ArticleLayout.astro";
 ---
 
 <ArticleLayout
-  title="The decision or system being described"
-  meta="YYYY-MM-DD · architecture"
-  subtitle="What this essay argues or explains — one sentence."
+  title={metadata.title}
+  meta={`${metadata.date} · ${metadata.tag}`}
+  subtitle={metadata.description}
   backHref="/architecture/"
   backLabel="← architecture"
 >

--- a/src/templates/note.astro
+++ b/src/templates/note.astro
@@ -5,19 +5,26 @@
 //
 // Checklist before publishing:
 //   [ ] Title is specific — describes the exact problem, not just the area
-//   [ ] Meta date is accurate (YYYY-MM-DD)
-//   [ ] Tag is one of: field note · debugging · security · architecture · platform
-//   [ ] Subtitle is one sentence — states what the note explains
+//   [ ] metadata.date is accurate (YYYY-MM-DD)
+//   [ ] metadata.tag is one of: field note · debugging · security · architecture · platform
+//   [ ] metadata.description is one sentence — states what the note explains
 //   [ ] backHref/nextHref links are correct
 //   [ ] No placeholder text remains
+
+export const metadata = {
+  title: "Short, specific title describing the exact problem",
+  date: "YYYY-MM-DD",
+  tag: "field note",
+  description: "One sentence. What does this note explain and why does it matter.",
+};
 
 import ArticleLayout from "@/layouts/ArticleLayout.astro";
 ---
 
 <ArticleLayout
-  title="Short, specific title describing the exact problem"
-  meta="YYYY-MM-DD · field note"
-  subtitle="One sentence. What does this note explain and why does it matter."
+  title={metadata.title}
+  meta={`${metadata.date} · ${metadata.tag}`}
+  subtitle={metadata.description}
   backHref="/notes/"
   backLabel="← all notes"
 >


### PR DESCRIPTION
## Summary

Replaces hardcoded post lists with `import.meta.glob` discovery so the homepage and index pages auto-populate as content PRs land.

## Changes

### `src/pages/index.astro`
- Globs `./notes/*/index.{astro,mdx}` and `./architecture/*/index.{astro,mdx}` at build time
- Combines and sorts all posts newest-first by `metadata.date`
- Shows the most recent post as the hero feature card, next 3 as the sidebar list
- Entire "recent" section is hidden when no posts exist

### `src/pages/notes/index.astro` / `src/pages/architecture/index.astro`
- Same glob approach, scoped to their respective subdirectory
- Empty state message when no posts are present

### `src/templates/note.astro` / `src/templates/architecture.astro`
- Added `export const metadata` as the required convention for post discovery
- `ArticleLayout` props now reference `metadata.*` — single source of truth per post

## Convention for new posts

Every post must export a metadata object from its frontmatter block:

```ts
export const metadata = {
  title: "Short, specific title",
  date: "YYYY-MM-DD",
  tag: "field note",
  description: "One sentence description.",
};
```

Posts without this export are silently ignored by the index pages.
