### PR TITLE
feat: replace hardcoded debug and projects lists with import.meta.glob discovery

### DIFF
--- a/src/pages/debug/index.astro
+++ b/src/pages/debug/index.astro
@@ -2,34 +2,27 @@
 import Layout from "@/layouts/Layout.astro";
 import Badge from "@/components/ui/Badge.astro";
 
-const entries = [
-  {
-    label: "kubernetes / tls",
-    title: "x509: certificate signed by unknown authority",
-    desc: "Check kubeconfig CA data, file permissions, ownership, KUBECONFIG env, and whether the API endpoint changed after bootstrap.",
-    tags: ["k3s", "kubectl", "tls"],
-    href: "/notes/k3s-tls-trust-errors/",
-  },
-  {
-    label: "traefik / crd",
-    title: "unknown field sniStrict",
-    desc: "Validate the installed Traefik CRD version before applying TLSOption fields. Do not assume examples match the deployed API.",
-    tags: ["traefik", "crd", "tlsoption"],
-  },
-  {
-    label: "kyverno / gpu",
-    title: "policy contains invalid variables",
-    desc: "Escape resource keys such as nvidia.com/gpu carefully when using JMESPath expressions in Kyverno policies.",
-    tags: ["kyverno", "nvidia", "jmespath"],
-    href: "/notes/nvidia-runtimeclass-gpu-workloads/",
-  },
-  {
-    label: "playwright / tests",
-    title: "TimeoutError waiting for networkidle",
-    desc: "Do not default to networkidle for apps with long-lived requests. Prefer a specific selector or a more targeted load state.",
-    tags: ["tests", "playwright", "ui"],
-  },
-];
+interface DebugMeta {
+  label: string;
+  title: string;
+  description: string;
+  tags: string[];
+  href?: string;
+}
+interface DebugModule { metadata?: DebugMeta; }
+
+function toHref(path: string) {
+  return '/debug' + path.replace(/^\.\//, '/').replace(/\/index\.(astro|mdx)$/, '/');
+}
+
+const modules = import.meta.glob<DebugModule>('./*/index.astro', { eager: true });
+
+const entries = Object.entries(modules)
+  .filter(([, m]) => m.metadata)
+  .map(([path, m]) => ({
+    href: m.metadata!.href ?? toHref(path),
+    ...m.metadata!,
+  }));
 ---
 
 <Layout title="Debug Archive — Vinicius Cerutti" description="A compact archive of symptoms, likely causes, and practical fixes for recurring infrastructure problems.">
@@ -42,22 +35,17 @@ const entries = [
 
       <section class="py-[clamp(36px,4vw,52px)]">
         <div class="debug-grid">
-          {entries.map(({ label, title, desc, tags, href }) => (
-            <div class="debug-card">
+          {entries.map(({ label, title, description, tags, href }) => (
+            <a href={href} class="debug-card">
               <div>
                 <div class="card-label">{label}</div>
-                <h2 class="card-title">
-                  {href
-                    ? <a href={href} class="hover:text-[var(--link)] transition-colors"><code>{title}</code></a>
-                    : <code>{title}</code>
-                  }
-                </h2>
-                <p class="card-desc">{desc}</p>
+                <h2 class="card-title"><code>{title}</code></h2>
+                <p class="card-desc">{description}</p>
               </div>
               <div class="flex flex-wrap gap-2 mt-5">
                 {tags.map(t => <Badge variant="outline">{t}</Badge>)}
               </div>
-            </div>
+            </a>
           ))}
         </div>
       </section>
@@ -99,7 +87,10 @@ const entries = [
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    text-decoration: none;
+    transition: border-color 160ms, background 160ms;
   }
+  .debug-card:hover { border-color: var(--border-strong); background: var(--surface-raised); }
   .card-label {
     font-family: var(--font-mono);
     font-size: 11px;

--- a/src/pages/debug/k3s-x509-unknown-authority/index.astro
+++ b/src/pages/debug/k3s-x509-unknown-authority/index.astro
@@ -1,0 +1,78 @@
+---
+export const metadata = {
+  label: "kubernetes / tls",
+  title: "x509: certificate signed by unknown authority",
+  description: "Check kubeconfig CA data, file permissions, ownership, KUBECONFIG env, and whether the API endpoint changed after bootstrap.",
+  tags: ["k3s", "kubectl", "tls"],
+  href: "/notes/k3s-tls-trust-errors/",
+};
+
+import Layout from "@/layouts/Layout.astro";
+import Badge from "@/components/ui/Badge.astro";
+---
+
+<Layout title="x509: certificate signed by unknown authority — Debug">
+  <div class="w-[min(820px,calc(100%-44px))] mx-auto py-[clamp(48px,6vw,80px)]">
+    <a href="/debug/" class="back-link">← debug archive</a>
+    <div class="kicker">kubernetes / tls</div>
+    <h1 class="entry-title"><code>x509: certificate signed by unknown authority</code></h1>
+    <p class="entry-desc">{metadata.description}</p>
+    <div class="flex flex-wrap gap-2 mt-6">
+      {metadata.tags.map((t: string) => <Badge variant="outline">{t}</Badge>)}
+    </div>
+    <div class="ref-link">
+      <a href="/notes/k3s-tls-trust-errors/">Full writeup in notes →</a>
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .back-link {
+    display: inline-block;
+    font-size: 13px;
+    color: var(--muted-foreground);
+    text-decoration: none;
+    margin-bottom: 32px;
+  }
+  .back-link:hover { color: var(--foreground); }
+  .kicker {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--faint);
+    margin-bottom: 14px;
+  }
+  .entry-title {
+    font-size: clamp(28px, 4vw, 40px);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 1.1;
+    color: var(--foreground);
+    margin: 0 0 20px;
+  }
+  .entry-title code {
+    font-family: var(--font-mono);
+    font-size: 0.82em;
+    color: #dfbb7f;
+    background: none;
+  }
+  .entry-desc {
+    font-size: 16px;
+    color: var(--muted-foreground);
+    line-height: 1.65;
+    margin: 0;
+    max-width: 680px;
+  }
+  .ref-link {
+    margin-top: 32px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
+  }
+  .ref-link a {
+    font-size: 14px;
+    color: var(--link);
+    text-decoration: none;
+  }
+  .ref-link a:hover { text-decoration: underline; }
+</style>

--- a/src/pages/debug/kyverno-invalid-variables/index.astro
+++ b/src/pages/debug/kyverno-invalid-variables/index.astro
@@ -1,0 +1,78 @@
+---
+export const metadata = {
+  label: "kyverno / gpu",
+  title: "policy contains invalid variables",
+  description: "Escape resource keys such as nvidia.com/gpu carefully when using JMESPath expressions in Kyverno policies.",
+  tags: ["kyverno", "nvidia", "jmespath"],
+  href: "/notes/nvidia-runtimeclass-gpu-workloads/",
+};
+
+import Layout from "@/layouts/Layout.astro";
+import Badge from "@/components/ui/Badge.astro";
+---
+
+<Layout title="policy contains invalid variables — Debug">
+  <div class="w-[min(820px,calc(100%-44px))] mx-auto py-[clamp(48px,6vw,80px)]">
+    <a href="/debug/" class="back-link">← debug archive</a>
+    <div class="kicker">kyverno / gpu</div>
+    <h1 class="entry-title"><code>policy contains invalid variables</code></h1>
+    <p class="entry-desc">{metadata.description}</p>
+    <div class="flex flex-wrap gap-2 mt-6">
+      {metadata.tags.map((t: string) => <Badge variant="outline">{t}</Badge>)}
+    </div>
+    <div class="ref-link">
+      <a href="/notes/nvidia-runtimeclass-gpu-workloads/">Full writeup in notes →</a>
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .back-link {
+    display: inline-block;
+    font-size: 13px;
+    color: var(--muted-foreground);
+    text-decoration: none;
+    margin-bottom: 32px;
+  }
+  .back-link:hover { color: var(--foreground); }
+  .kicker {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--faint);
+    margin-bottom: 14px;
+  }
+  .entry-title {
+    font-size: clamp(28px, 4vw, 40px);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 1.1;
+    color: var(--foreground);
+    margin: 0 0 20px;
+  }
+  .entry-title code {
+    font-family: var(--font-mono);
+    font-size: 0.82em;
+    color: #dfbb7f;
+    background: none;
+  }
+  .entry-desc {
+    font-size: 16px;
+    color: var(--muted-foreground);
+    line-height: 1.65;
+    margin: 0;
+    max-width: 680px;
+  }
+  .ref-link {
+    margin-top: 32px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
+  }
+  .ref-link a {
+    font-size: 14px;
+    color: var(--link);
+    text-decoration: none;
+  }
+  .ref-link a:hover { text-decoration: underline; }
+</style>

--- a/src/pages/debug/playwright-timeout-networkidle/index.astro
+++ b/src/pages/debug/playwright-timeout-networkidle/index.astro
@@ -1,0 +1,63 @@
+---
+export const metadata = {
+  label: "playwright / tests",
+  title: "TimeoutError waiting for networkidle",
+  description: "Do not default to networkidle for apps with long-lived requests. Prefer a specific selector or a more targeted load state.",
+  tags: ["tests", "playwright", "ui"],
+};
+
+import Layout from "@/layouts/Layout.astro";
+import Badge from "@/components/ui/Badge.astro";
+---
+
+<Layout title="TimeoutError waiting for networkidle — Debug">
+  <div class="w-[min(820px,calc(100%-44px))] mx-auto py-[clamp(48px,6vw,80px)]">
+    <a href="/debug/" class="back-link">← debug archive</a>
+    <div class="kicker">playwright / tests</div>
+    <h1 class="entry-title"><code>TimeoutError waiting for networkidle</code></h1>
+    <p class="entry-desc">{metadata.description}</p>
+    <div class="flex flex-wrap gap-2 mt-6">
+      {metadata.tags.map((t: string) => <Badge variant="outline">{t}</Badge>)}
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .back-link {
+    display: inline-block;
+    font-size: 13px;
+    color: var(--muted-foreground);
+    text-decoration: none;
+    margin-bottom: 32px;
+  }
+  .back-link:hover { color: var(--foreground); }
+  .kicker {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--faint);
+    margin-bottom: 14px;
+  }
+  .entry-title {
+    font-size: clamp(28px, 4vw, 40px);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 1.1;
+    color: var(--foreground);
+    margin: 0 0 20px;
+  }
+  .entry-title code {
+    font-family: var(--font-mono);
+    font-size: 0.82em;
+    color: #dfbb7f;
+    background: none;
+  }
+  .entry-desc {
+    font-size: 16px;
+    color: var(--muted-foreground);
+    line-height: 1.65;
+    margin: 0;
+    max-width: 680px;
+  }
+</style>

--- a/src/pages/debug/traefik-crd-snistrict/index.astro
+++ b/src/pages/debug/traefik-crd-snistrict/index.astro
@@ -1,0 +1,63 @@
+---
+export const metadata = {
+  label: "traefik / crd",
+  title: "unknown field sniStrict",
+  description: "Validate the installed Traefik CRD version before applying TLSOption fields. Do not assume examples match the deployed API.",
+  tags: ["traefik", "crd", "tlsoption"],
+};
+
+import Layout from "@/layouts/Layout.astro";
+import Badge from "@/components/ui/Badge.astro";
+---
+
+<Layout title="unknown field sniStrict — Debug">
+  <div class="w-[min(820px,calc(100%-44px))] mx-auto py-[clamp(48px,6vw,80px)]">
+    <a href="/debug/" class="back-link">← debug archive</a>
+    <div class="kicker">traefik / crd</div>
+    <h1 class="entry-title"><code>unknown field sniStrict</code></h1>
+    <p class="entry-desc">{metadata.description}</p>
+    <div class="flex flex-wrap gap-2 mt-6">
+      {metadata.tags.map((t: string) => <Badge variant="outline">{t}</Badge>)}
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .back-link {
+    display: inline-block;
+    font-size: 13px;
+    color: var(--muted-foreground);
+    text-decoration: none;
+    margin-bottom: 32px;
+  }
+  .back-link:hover { color: var(--foreground); }
+  .kicker {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--faint);
+    margin-bottom: 14px;
+  }
+  .entry-title {
+    font-size: clamp(28px, 4vw, 40px);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 1.1;
+    color: var(--foreground);
+    margin: 0 0 20px;
+  }
+  .entry-title code {
+    font-family: var(--font-mono);
+    font-size: 0.82em;
+    color: #dfbb7f;
+    background: none;
+  }
+  .entry-desc {
+    font-size: 16px;
+    color: var(--muted-foreground);
+    line-height: 1.65;
+    margin: 0;
+    max-width: 680px;
+  }
+</style>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -2,50 +2,23 @@
 import Layout from "@/layouts/Layout.astro";
 import Badge from "@/components/ui/Badge.astro";
 
-const projects = [
-  {
-    href: "/projects/nebari-infrastructure-core/",
-    label: "platform",
-    title: "Nebari Infrastructure Core",
-    desc: "A Go-first direction for managing cloud resources and platform services with declarative workflows.",
-    tags: ["go", "kubernetes", "gitops"],
-  },
-  {
-    href: "/projects/keycloak-backup-restore/",
-    label: "reliability",
-    title: "Keycloak backup and restore",
-    desc: "State recreation, topological ordering, restore planning, and conflict handling for identity platform objects.",
-    tags: ["python", "keycloak", "fastapi"],
-  },
-  {
-    href: "/projects/gsoc-conda-forge-autotick/",
-    label: "open source · 2020",
-    title: "conda-forge auto-tick bot",
-    desc: "GSoC 2020. Extracting the version-update pipeline from the conda-forge dependency graph into a standalone microservice.",
-    tags: ["python", "conda-forge", "dynamodb"],
-  },
-  {
-    href: "/projects/protein-refinement/",
-    label: "research · thesis",
-    title: "Protein conformation from distances",
-    desc: "Undergraduate thesis. Recovering 3D molecular structure from sparse inter-atomic distance bounds using SDP relaxation and SPG refinement.",
-    tags: ["python", "matlab", "numpy"],
-  },
-  {
-    href: "/projects/procurement-crawlers/",
-    label: "automation",
-    title: "Procurement crawlers",
-    desc: "Scrapy and browser-assisted crawlers for procurement portals — attachments, pagination, and normalization.",
-    tags: ["python", "scrapy", "selenium"],
-  },
-  {
-    href: "/projects/k3s-platform-testbeds/",
-    label: "operations",
-    title: "K3s platform testbeds",
-    desc: "HA clusters, MetalLB, Traefik, GPU nodes, firewalld, and local Vagrant/libvirt environments for platform experiments.",
-    tags: ["k3s", "rhel9", "gpu"],
-  },
-];
+interface ProjectMeta {
+  label: string;
+  title: string;
+  description: string;
+  tags: string[];
+}
+interface ProjectModule { metadata?: ProjectMeta; }
+
+function toHref(path: string) {
+  return '/projects' + path.replace(/^\.\//, '/').replace(/\/index\.(astro|mdx)$/, '/');
+}
+
+const modules = import.meta.glob<ProjectModule>('./*/index.astro', { eager: true });
+
+const projects = Object.entries(modules)
+  .filter(([, m]) => m.metadata)
+  .map(([path, m]) => ({ href: toHref(path), ...m.metadata! }));
 ---
 
 <Layout title="Projects — Vinicius Cerutti" description="Selected systems, tools, and platform work.">
@@ -58,21 +31,18 @@ const projects = [
 
       <section class="py-[clamp(36px,4vw,52px)]">
         <div class="grid grid-cols-2 gap-3.5">
-          {projects.map(({ href, label, title, desc, tags }) => {
-            const Tag = href ? "a" : "div";
-            return (
-              <Tag href={href} class={"project-card" + (href ? " is-link" : "")}>
+          {projects.map(({ href, label, title, description, tags }) => (
+              <a href={href} class="project-card is-link">
                 <div>
                   <div class="card-label">{label}</div>
                   <h2 class="card-title">{title}</h2>
-                  <p class="card-desc">{desc}</p>
+                  <p class="card-desc">{description}</p>
                 </div>
                 <div class="flex flex-wrap gap-2 mt-5">
                   {tags.map(t => <Badge variant="outline">{t}</Badge>)}
                 </div>
-              </Tag>
-            );
-          })}
+              </a>
+          ))}
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary

Extends the `import.meta.glob` discovery pattern (introduced in `feat/dynamic-post-discovery`) to cover the **debug** and **projects** sections, eliminating the last two hardcoded content arrays.

## Changes

### `src/pages/projects/*/index.astro` (6 files)
- Added `export const metadata` to each project page with `label`, `title`, `description`, and `tags`

### `src/pages/projects/index.astro`
- Replaced hardcoded `projects` array with `import.meta.glob("./*/index.astro", { eager: true })`
- Href is derived from the file path; only files that export `metadata` are included

### `src/pages/debug/*/index.astro` (4 new files)
- Created individual sub-pages for each debug entry (`k3s-x509-unknown-authority`, `traefik-crd-snistrict`, `kyverno-invalid-variables`, `playwright-timeout-networkidle`)
- Each exports metadata (`label`, `title`, `description`, `tags`, optional `href`)
- Each page has a standalone layout with a back-link and optional reference to a related notes article

### `src/pages/debug/index.astro`
- Replaced hardcoded `entries` array with `import.meta.glob("./*/index.astro", { eager: true })`
- Cards with `href` in metadata link to the related notes page; others link to the debug sub-page
- All cards are now full clickable links with hover behavior (consistent with project cards)

## Before / After

```bash
# Before: adding a new project or debug entry required editing
# the hardcoded array in the index page directly

# After: drop a new index.astro with export const metadata into
# the directory — it appears automatically on the index page at next build
```
