### PR TITLE
docs: rewrite README and update repo description

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -32,24 +32,15 @@
   <!-- Left accent bar -->
   <rect x="0" y="0" width="3" height="240" fill="#5eead4"/>
 
-  <!-- Horizontal rule -->
-  <line x1="72" y1="158" x2="520" y2="158" stroke="#1e2530" stroke-width="1"/>
-
   <!-- Title: vinicius -->
-  <text x="72" y="122"
+  <text x="72" y="132"
     font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
     font-size="68" font-weight="700" fill="#e2e8f0"
     letter-spacing="-2">vinicius</text>
 
   <!-- Title: .dev accent -->
-  <text x="450" y="122"
+  <text x="450" y="132"
     font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
     font-size="68" font-weight="700" fill="#5eead4"
     letter-spacing="-2">.dev</text>
-
-  <!-- Tagline -->
-  <text x="73" y="188"
-    font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
-    font-size="13" font-weight="400" fill="#475569"
-    letter-spacing="3">KUBERNETES · TLS · IDENTITY · GPU RUNTIMES · OPERATOR DESIGN</text>
 </svg>

--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 240" width="1200" height="240">
+  <defs>
+    <radialGradient id="glow" cx="78%" cy="50%" r="38%">
+      <stop offset="0%" stop-color="#5eead4" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#5eead4" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1" fill="#5eead4" fill-opacity="0.12"/>
+    </pattern>
+    <clipPath id="clip">
+      <rect width="1200" height="240" rx="0"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="240" fill="#090b0f"/>
+
+  <!-- Dot grid (right half) -->
+  <rect x="560" y="0" width="640" height="240" fill="url(#dots)" clip-path="url(#clip)"/>
+
+  <!-- Radial glow -->
+  <rect width="1200" height="240" fill="url(#glow)"/>
+
+  <!-- Concentric circles (right anchor) -->
+  <circle cx="1020" cy="120" r="180" fill="none" stroke="#5eead4" stroke-width="0.8" stroke-opacity="0.10"/>
+  <circle cx="1020" cy="120" r="140" fill="none" stroke="#5eead4" stroke-width="0.8" stroke-opacity="0.13"/>
+  <circle cx="1020" cy="120" r="100" fill="none" stroke="#5eead4" stroke-width="0.9" stroke-opacity="0.17"/>
+  <circle cx="1020" cy="120" r="60"  fill="none" stroke="#5eead4" stroke-width="1.0" stroke-opacity="0.22"/>
+  <circle cx="1020" cy="120" r="26"  fill="none" stroke="#5eead4" stroke-width="1.2" stroke-opacity="0.30"/>
+  <circle cx="1020" cy="120" r="4"   fill="#5eead4" fill-opacity="0.50"/>
+
+  <!-- Left accent bar -->
+  <rect x="0" y="0" width="3" height="240" fill="#5eead4"/>
+
+  <!-- Horizontal rule -->
+  <line x1="72" y1="158" x2="520" y2="158" stroke="#1e2530" stroke-width="1"/>
+
+  <!-- Title: vinicius -->
+  <text x="72" y="122"
+    font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
+    font-size="68" font-weight="700" fill="#e2e8f0"
+    letter-spacing="-2">vinicius</text>
+
+  <!-- Title: .dev accent -->
+  <text x="450" y="122"
+    font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
+    font-size="68" font-weight="700" fill="#5eead4"
+    letter-spacing="-2">.dev</text>
+
+  <!-- Tagline -->
+  <text x="73" y="188"
+    font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
+    font-size="13" font-weight="400" fill="#475569"
+    letter-spacing="3">KUBERNETES · TLS · IDENTITY · GPU RUNTIMES · OPERATOR DESIGN</text>
+</svg>

--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -12,33 +12,24 @@
     </clipPath>
   </defs>
 
-  <!-- Background -->
   <rect width="1200" height="240" fill="#090b0f"/>
-
-  <!-- Dot grid (right half) -->
   <rect x="560" y="0" width="640" height="240" fill="url(#dots)" clip-path="url(#clip)"/>
-
-  <!-- Radial glow -->
   <rect width="1200" height="240" fill="url(#glow)"/>
 
-  <!-- Concentric circles (right anchor) -->
-  <circle cx="1020" cy="120" r="180" fill="none" stroke="#5eead4" stroke-width="0.8" stroke-opacity="0.10"/>
+  <circle cx="1020" cy="120" r="180" fill="none" stroke="#5eead4" stroke-width="0.8" stroke-opacity="0.1"/>
   <circle cx="1020" cy="120" r="140" fill="none" stroke="#5eead4" stroke-width="0.8" stroke-opacity="0.13"/>
   <circle cx="1020" cy="120" r="100" fill="none" stroke="#5eead4" stroke-width="0.9" stroke-opacity="0.17"/>
-  <circle cx="1020" cy="120" r="60"  fill="none" stroke="#5eead4" stroke-width="1.0" stroke-opacity="0.22"/>
-  <circle cx="1020" cy="120" r="26"  fill="none" stroke="#5eead4" stroke-width="1.2" stroke-opacity="0.30"/>
-  <circle cx="1020" cy="120" r="4"   fill="#5eead4" fill-opacity="0.50"/>
+  <circle cx="1020" cy="120" r="60" fill="none" stroke="#5eead4" stroke-width="1" stroke-opacity="0.22"/>
+  <circle cx="1020" cy="120" r="26" fill="none" stroke="#5eead4" stroke-width="1.2" stroke-opacity="0.3"/>
+  <circle cx="1020" cy="120" r="4" fill="#5eead4" fill-opacity="0.50"/>
 
-  <!-- Left accent bar -->
   <rect x="0" y="0" width="3" height="240" fill="#5eead4"/>
 
-  <!-- Title: vinicius -->
   <text x="72" y="132"
     font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
     font-size="68" font-weight="700" fill="#e2e8f0"
     letter-spacing="-2">vinicius</text>
 
-  <!-- Title: .dev accent -->
   <text x="450" y="132"
     font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
     font-size="68" font-weight="700" fill="#5eead4"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: install dev build preview check banner post
+
+# ── npm ───────────────────────────────────────────────────────────────────────
+
+install:
+	npm install
+
+dev:
+	npm run dev
+
+build:
+	npm run build
+
+preview:
+	npm run preview
+
+check:
+	npm run check
+
+# ── assets ────────────────────────────────────────────────────────────────────
+
+banner:
+	node scripts/gen-banner.mjs
+
+# ── content ───────────────────────────────────────────────────────────────────
+#
+#   make post TITLE="k3s coredns loop"                   → notes post, tag=field note
+#   make post TITLE="k3s coredns loop" TAG="debugging"   → notes post, tag=debugging
+#   make post TITLE="operator ownership" TYPE=arch        → architecture essay
+
+post:
+ifndef TITLE
+	$(error TITLE is required.  make post TITLE="my title" TAG="debugging" TYPE=note)
+endif
+	@chmod +x scripts/new-post.sh
+	@scripts/new-post.sh "$(TITLE)" "$(or $(TAG),field note)" "$(or $(TYPE),note)"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
-# viniciusdc.github.io
+<div align="center">
 
-Personal site — Kubernetes, platform engineering, TLS, identity, GPU runtimes, and the architecture decisions worth writing down.
+<h1>viniciusdc.github.io</h1>
 
-[![Deploy](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
-&nbsp;&nbsp;**→** [viniciusdc.github.io](https://viniciusdc.github.io)
+<p>Platform engineering field notes, architecture essays, and project writeups.<br>
+<sub>Kubernetes &nbsp;·&nbsp; TLS &nbsp;·&nbsp; identity &nbsp;·&nbsp; GPU runtimes &nbsp;·&nbsp; operator design</sub></p>
+
+[![site](https://img.shields.io/badge/viniciusdc.github.io-live-5eead4?style=flat-square)](https://viniciusdc.github.io)
+[![deploy](https://img.shields.io/github/actions/workflow/status/viniciusdc/viniciusdc.github.io/deploy.yml?branch=gh-pages&style=flat-square&label=deploy)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
+
+<br>
+
+![Astro](https://img.shields.io/badge/Astro_6-BC52EE?style=flat-square&logo=astro&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS_v4-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
+![MDX](https://img.shields.io/badge/MDX-F9AC00?style=flat-square&logo=mdx&logoColor=black)
+
+</div>
 
 ---
-
-## Stack
-
-Built with [Astro 6](https://astro.build), [Tailwind CSS v4](https://tailwindcss.com), and [MDX](https://mdxjs.com). Deployed to GitHub Pages via GitHub Actions.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,9 @@
 
 <img src=".github/banner.svg" alt="vinicius.dev — platform engineering field notes" width="100%"/>
 
-<br>
+[![site](https://img.shields.io/badge/viniciusdc.github.io-live-5eead4?style=flat-square)](https://viniciusdc.github.io) [![deploy](https://img.shields.io/github/actions/workflow/status/viniciusdc/viniciusdc.github.io/deploy.yml?branch=gh-pages&style=flat-square&label=deploy)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
 
-[![site](https://img.shields.io/badge/viniciusdc.github.io-live-5eead4?style=flat-square)](https://viniciusdc.github.io)
-[![deploy](https://img.shields.io/github/actions/workflow/status/viniciusdc/viniciusdc.github.io/deploy.yml?branch=gh-pages&style=flat-square&label=deploy)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
-
-<br>
-
-![Astro](https://img.shields.io/badge/Astro_6-BC52EE?style=flat-square&logo=astro&logoColor=white)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS_v4-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white)
-![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
-![MDX](https://img.shields.io/badge/MDX-F9AC00?style=flat-square&logo=mdx&logoColor=black)
+![Astro](https://img.shields.io/badge/Astro_6-BC52EE?style=flat-square&logo=astro&logoColor=white) ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS_v4-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white) ![MDX](https://img.shields.io/badge/MDX-F9AC00?style=flat-square&logo=mdx&logoColor=black)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,54 @@
 # viniciusdc.github.io
 
-> Platform engineering field notes, architecture essays, and project writeups.
+Personal site — Kubernetes, platform engineering, TLS, identity, GPU runtimes, and the architecture decisions worth writing down.
 
 [![Deploy](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
-[![CI](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/ci.yml)
-
-**Live site → [viniciusdc.github.io](https://viniciusdc.github.io)**
+&nbsp;&nbsp;**→** [viniciusdc.github.io](https://viniciusdc.github.io)
 
 ---
 
-## 🚀 Stack
+## Stack
 
-| | |
-|---|---|
-| Framework | [Astro 6](https://astro.build) |
-| Styling | [Tailwind CSS v4](https://tailwindcss.com) |
-| Content | [MDX](https://mdxjs.com) + `.astro` pages |
-| Hosting | GitHub Pages via GitHub Actions |
+Built with [Astro 6](https://astro.build), [Tailwind CSS v4](https://tailwindcss.com), and [MDX](https://mdxjs.com). Deployed to GitHub Pages via GitHub Actions.
 
-## 🧞 Commands
+## Commands
 
 ```sh
-npm install          # install dependencies
-npm run dev          # dev server at http://localhost:4321
-npm run build        # production build → dist/
-npm run preview      # preview the dist/ build locally
-npm run spell        # run cspell spell-check locally
+npm install       # install dependencies
+npm run dev       # dev server → http://localhost:4321
+npm run build     # production build → dist/
+npm run preview   # serve dist/ locally
+npm run check     # type-check + spell-check
 ```
 
-## 📁 Project structure
+## Project structure
 
 ```
 src/
-├── layouts/         # Layout.astro, ArticleLayout.astro
+├── layouts/           # Layout.astro, ArticleLayout.astro
 ├── pages/
-│   ├── index.astro  # homepage
-│   ├── notes/       # field notes (gitignored, committed via content PRs)
-│   ├── architecture/# design essays (gitignored, committed via content PRs)
-│   ├── projects/    # project writeups
-│   ├── debug/       # debugging reference index
+│   ├── index.astro    # homepage
+│   ├── notes/         # field notes       ← gitignored, committed via content PRs
+│   ├── architecture/  # design essays     ← gitignored, committed via content PRs
+│   ├── projects/      # project writeups
+│   ├── debug/         # debugging reference
 │   └── about/
-├── components/
-│   └── ui/          # Badge.astro and other primitives
-├── styles/
-│   └── global.css
-└── templates/       # note.astro, architecture.astro — copy to start a post
+├── components/ui/     # Badge.astro and other primitives
+├── styles/global.css
+└── templates/         # copy to start a new post
+public/                # favicon and static assets
 ```
 
-## ✍️ Adding content
+## Writing a post
 
-Copy a template from `src/templates/`, then fill in the `metadata` export at the top of the file — this is what the homepage and index pages use to auto-discover posts at build time:
+Copy `src/templates/note.astro` or `src/templates/architecture.astro`, then fill in the `metadata` export — the homepage and index pages auto-discover posts from this at build time:
 
 ```ts
 export const metadata = {
-  title: "Short, specific title describing the exact problem",
+  title: "Short, specific title",
   date: "YYYY-MM-DD",
-  tag: "field note",          // field note · debugging · security · architecture · platform
-  description: "One sentence. What does this note explain and why does it matter.",
+  tag: "field note",   // field note · debugging · security · architecture · platform
+  description: "One sentence describing what this explains.",
 };
 ```
 
@@ -67,13 +59,13 @@ scripts/new-note.sh <slug>
 scripts/new-architecture.sh <slug>
 ```
 
-## 🔁 CI / CD
+## CI / CD
 
-| Job | Runs on | Does |
+| Job | Trigger | |
 |---|---|---|
-| **Build** | PR | Compiles the site, uploads `dist/` artifact |
-| **Spell check** | PR | cspell across `.astro` and `.mdx` source files |
-| **Lighthouse audit** | PR | Scores accessibility, SEO, best-practices, performance |
-| **Deploy** | Push to `gh-pages` | Builds and publishes to GitHub Pages |
+| Build | PR | Compiles the site and uploads `dist/` as an artifact |
+| Spell check | PR | cspell over all `.astro` and `.mdx` source files |
+| Lighthouse | PR | Accessibility, SEO, best-practices ≥ 100 · performance ≥ 90 |
+| Deploy | Push to `gh-pages` | Builds and publishes to GitHub Pages |
 
-All actions are pinned to commit SHAs. Dependabot opens weekly PRs to keep action SHAs and npm deps current.
+Actions are pinned to commit SHAs. Dependabot opens weekly PRs to keep action SHAs and npm deps current.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,64 @@
-# Astro Starter Kit: Minimal
+# viniciusdc.github.io
+
+Personal site — platform engineering field notes, architecture essays, and project writeups.
+
+**[viniciusdc.github.io](https://viniciusdc.github.io)**
+
+---
+
+## Stack
+
+- [Astro 6](https://astro.build) — static site generator
+- [Tailwind CSS v4](https://tailwindcss.com) — utility-first CSS
+- [MDX](https://mdxjs.com) — markdown with component support
+- Deployed to GitHub Pages via GitHub Actions
+
+## Local development
 
 ```sh
-npm create astro@latest -- --template minimal
+npm install
+npm run dev        # http://localhost:4321
+npm run build      # production build to dist/
+npm run preview    # serve the dist/ build locally
 ```
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Content
 
-## 🚀 Project Structure
+Content lives under `src/pages/` and is gitignored by default — posts are committed via separate PRs.
 
-Inside of your Astro project, you'll see the following folders and files:
+| Section | Path | Format |
+|---|---|---|
+| Field notes | `src/pages/notes/<slug>/index.astro` | Short technical writeups |
+| Architecture | `src/pages/architecture/<slug>/index.astro` | Long-form design essays |
+| Projects | `src/pages/projects/<slug>/index.astro` | Project writeups |
 
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
+### Adding a new post
+
+Copy the relevant template from `src/templates/` and fill in the `metadata` export — this drives the index pages and homepage:
+
+```ts
+export const metadata = {
+  title: "Short, specific title",
+  date: "YYYY-MM-DD",
+  tag: "field note",
+  description: "One sentence description.",
+};
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+Scripts to scaffold a new post:
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+```sh
+scripts/new-note.sh <slug>
+scripts/new-architecture.sh <slug>
+```
 
-Any static assets, like images, can be placed in the `public/` directory.
+## CI
 
-## 🧞 Commands
+| Job | Trigger | Purpose |
+|---|---|---|
+| Build | PR | Verify the site compiles |
+| Spell check | PR | cspell across all `.astro` and `.mdx` files |
+| Lighthouse audit | PR | Accessibility, SEO, best-practices, performance |
+| Deploy | Push to `gh-pages` | Build and publish to GitHub Pages |
 
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Dependabot runs weekly to keep npm deps and action SHAs current.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@
 ## Commands
 
 ```sh
-npm install       # install dependencies
-npm run dev       # dev server → http://localhost:4321
-npm run build     # production build → dist/
-npm run preview   # serve dist/ locally
-npm run check     # type-check + spell-check
+make install      # npm install
+make dev          # dev server → http://localhost:4321
+make build        # production build → dist/
+make preview      # serve dist/ locally
+make check        # type-check + spell-check
+make banner       # regenerate .github/banner.svg
 ```
 
 ## Project structure
@@ -35,13 +36,22 @@ src/
 │   └── about/
 ├── components/ui/     # Badge.astro and other primitives
 ├── styles/global.css
-└── templates/         # copy to start a new post
+└── templates/         # note.mdx and architecture.mdx starters
 public/                # favicon and static assets
+scripts/               # gen-banner.mjs, new-post.sh
 ```
 
 ## Writing a post
 
-Copy `src/templates/note.astro` or `src/templates/architecture.astro`, then fill in the `metadata` export — the homepage and index pages auto-discover posts from this at build time:
+Scaffold a new post with `make post` — the slug is derived from the title automatically:
+
+```sh
+make post TITLE="k3s coredns loop"                          # field note (default)
+make post TITLE="k3s coredns loop" TAG="debugging"          # custom tag
+make post TITLE="operator ownership boundaries" TYPE=arch   # architecture essay
+```
+
+Posts are `.mdx` files. Each exports a `metadata` object that the homepage and index pages discover at build time — no manual registration needed:
 
 ```ts
 export const metadata = {
@@ -50,13 +60,6 @@ export const metadata = {
   tag: "field note",   // field note · debugging · security · architecture · platform
   description: "One sentence describing what this explains.",
 };
-```
-
-Scaffold scripts handle the boilerplate:
-
-```sh
-scripts/new-note.sh <slug>
-scripts/new-architecture.sh <slug>
 ```
 
 ## CI / CD

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 <div align="center">
 
-<h1>viniciusdc.github.io</h1>
+<img src=".github/banner.svg" alt="vinicius.dev — platform engineering field notes" width="100%"/>
 
-<p>Platform engineering field notes, architecture essays, and project writeups.<br>
-<sub>Kubernetes &nbsp;·&nbsp; TLS &nbsp;·&nbsp; identity &nbsp;·&nbsp; GPU runtimes &nbsp;·&nbsp; operator design</sub></p>
+<br>
 
 [![site](https://img.shields.io/badge/viniciusdc.github.io-live-5eead4?style=flat-square)](https://viniciusdc.github.io)
 [![deploy](https://img.shields.io/github/actions/workflow/status/viniciusdc/viniciusdc.github.io/deploy.yml?branch=gh-pages&style=flat-square&label=deploy)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)

--- a/README.md
+++ b/README.md
@@ -1,64 +1,79 @@
 # viniciusdc.github.io
 
-Personal site — platform engineering field notes, architecture essays, and project writeups.
+> Platform engineering field notes, architecture essays, and project writeups.
 
-**[viniciusdc.github.io](https://viniciusdc.github.io)**
+[![Deploy](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
+[![CI](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/ci.yml)
+
+**Live site → [viniciusdc.github.io](https://viniciusdc.github.io)**
 
 ---
 
-## Stack
+## 🚀 Stack
 
-- [Astro 6](https://astro.build) — static site generator
-- [Tailwind CSS v4](https://tailwindcss.com) — utility-first CSS
-- [MDX](https://mdxjs.com) — markdown with component support
-- Deployed to GitHub Pages via GitHub Actions
+| | |
+|---|---|
+| Framework | [Astro 6](https://astro.build) |
+| Styling | [Tailwind CSS v4](https://tailwindcss.com) |
+| Content | [MDX](https://mdxjs.com) + `.astro` pages |
+| Hosting | GitHub Pages via GitHub Actions |
 
-## Local development
+## 🧞 Commands
 
 ```sh
-npm install
-npm run dev        # http://localhost:4321
-npm run build      # production build to dist/
-npm run preview    # serve the dist/ build locally
+npm install          # install dependencies
+npm run dev          # dev server at http://localhost:4321
+npm run build        # production build → dist/
+npm run preview      # preview the dist/ build locally
+npm run spell        # run cspell spell-check locally
 ```
 
-## Content
+## 📁 Project structure
 
-Content lives under `src/pages/` and is gitignored by default — posts are committed via separate PRs.
+```
+src/
+├── layouts/         # Layout.astro, ArticleLayout.astro
+├── pages/
+│   ├── index.astro  # homepage
+│   ├── notes/       # field notes (gitignored, committed via content PRs)
+│   ├── architecture/# design essays (gitignored, committed via content PRs)
+│   ├── projects/    # project writeups
+│   ├── debug/       # debugging reference index
+│   └── about/
+├── components/
+│   └── ui/          # Badge.astro and other primitives
+├── styles/
+│   └── global.css
+└── templates/       # note.astro, architecture.astro — copy to start a post
+```
 
-| Section | Path | Format |
-|---|---|---|
-| Field notes | `src/pages/notes/<slug>/index.astro` | Short technical writeups |
-| Architecture | `src/pages/architecture/<slug>/index.astro` | Long-form design essays |
-| Projects | `src/pages/projects/<slug>/index.astro` | Project writeups |
+## ✍️ Adding content
 
-### Adding a new post
-
-Copy the relevant template from `src/templates/` and fill in the `metadata` export — this drives the index pages and homepage:
+Copy a template from `src/templates/`, then fill in the `metadata` export at the top of the file — this is what the homepage and index pages use to auto-discover posts at build time:
 
 ```ts
 export const metadata = {
-  title: "Short, specific title",
+  title: "Short, specific title describing the exact problem",
   date: "YYYY-MM-DD",
-  tag: "field note",
-  description: "One sentence description.",
+  tag: "field note",          // field note · debugging · security · architecture · platform
+  description: "One sentence. What does this note explain and why does it matter.",
 };
 ```
 
-Scripts to scaffold a new post:
+Scaffold scripts handle the boilerplate:
 
 ```sh
 scripts/new-note.sh <slug>
 scripts/new-architecture.sh <slug>
 ```
 
-## CI
+## 🔁 CI / CD
 
-| Job | Trigger | Purpose |
+| Job | Runs on | Does |
 |---|---|---|
-| Build | PR | Verify the site compiles |
-| Spell check | PR | cspell across all `.astro` and `.mdx` files |
-| Lighthouse audit | PR | Accessibility, SEO, best-practices, performance |
-| Deploy | Push to `gh-pages` | Build and publish to GitHub Pages |
+| **Build** | PR | Compiles the site, uploads `dist/` artifact |
+| **Spell check** | PR | cspell across `.astro` and `.mdx` source files |
+| **Lighthouse audit** | PR | Scores accessibility, SEO, best-practices, performance |
+| **Deploy** | Push to `gh-pages` | Builds and publishes to GitHub Pages |
 
-Dependabot runs weekly to keep npm deps and action SHAs current.
+All actions are pinned to commit SHAs. Dependabot opens weekly PRs to keep action SHAs and npm deps current.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 <img src=".github/banner.svg" alt="vinicius.dev — platform engineering field notes" width="100%"/>
 
-[![site](https://img.shields.io/badge/viniciusdc.github.io-live-5eead4?style=flat-square)](https://viniciusdc.github.io) [![deploy](https://img.shields.io/github/actions/workflow/status/viniciusdc/viniciusdc.github.io/deploy.yml?branch=gh-pages&style=flat-square&label=deploy)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
+---
 
+[![site](https://img.shields.io/badge/viniciusdc.github.io-live-5eead4?style=flat-square)](https://viniciusdc.github.io) [![deploy](https://img.shields.io/github/actions/workflow/status/viniciusdc/viniciusdc.github.io/deploy.yml?branch=gh-pages&style=flat-square&label=deploy)](https://github.com/viniciusdc/viniciusdc.github.io/actions/workflows/deploy.yml)
 ![Astro](https://img.shields.io/badge/Astro_6-BC52EE?style=flat-square&logo=astro&logoColor=white) ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS_v4-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white) ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white) ![MDX](https://img.shields.io/badge/MDX-F9AC00?style=flat-square&logo=mdx&logoColor=black)
 
 </div>

--- a/scripts/gen-banner.mjs
+++ b/scripts/gen-banner.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Regenerates .github/banner.svg
+// Usage: node scripts/gen-banner.mjs
+
+import { writeFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dir, "../.github/banner.svg");
+
+const W = 1200;
+const H = 240;
+
+const COLORS = {
+  bg: "#090b0f",
+  text: "#e2e8f0",
+  accent: "#5eead4",
+  dots: "#5eead4",
+  muted: "#475569",
+  rule: "#1e2530",
+};
+
+const FONT = "ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace";
+
+const circles = [
+  { r: 180, w: 0.8, o: 0.10 },
+  { r: 140, w: 0.8, o: 0.13 },
+  { r: 100, w: 0.9, o: 0.17 },
+  { r: 60,  w: 1.0, o: 0.22 },
+  { r: 26,  w: 1.2, o: 0.30 },
+];
+const cx = 1020;
+const cy = H / 2;
+
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}">
+  <defs>
+    <radialGradient id="glow" cx="78%" cy="50%" r="38%">
+      <stop offset="0%" stop-color="${COLORS.accent}" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="${COLORS.accent}" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1" fill="${COLORS.dots}" fill-opacity="0.12"/>
+    </pattern>
+    <clipPath id="clip">
+      <rect width="${W}" height="${H}" rx="0"/>
+    </clipPath>
+  </defs>
+
+  <rect width="${W}" height="${H}" fill="${COLORS.bg}"/>
+  <rect x="560" y="0" width="640" height="${H}" fill="url(#dots)" clip-path="url(#clip)"/>
+  <rect width="${W}" height="${H}" fill="url(#glow)"/>
+
+${circles.map(({ r, w, o }) =>
+  `  <circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke="${COLORS.accent}" stroke-width="${w}" stroke-opacity="${o}"/>`
+).join("\n")}
+  <circle cx="${cx}" cy="${cy}" r="4" fill="${COLORS.accent}" fill-opacity="0.50"/>
+
+  <rect x="0" y="0" width="3" height="${H}" fill="${COLORS.accent}"/>
+
+  <text x="72" y="132"
+    font-family="${FONT}"
+    font-size="68" font-weight="700" fill="${COLORS.text}"
+    letter-spacing="-2">vinicius</text>
+
+  <text x="450" y="132"
+    font-family="${FONT}"
+    font-size="68" font-weight="700" fill="${COLORS.accent}"
+    letter-spacing="-2">.dev</text>
+</svg>
+`;
+
+writeFileSync(OUT, svg);
+console.log(`wrote ${OUT}`);

--- a/scripts/new-post.sh
+++ b/scripts/new-post.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: scripts/new-post.sh <title> [tag] [type]
+# Called by: make post TITLE="..." TAG="..." TYPE=note|arch
+
+TITLE="${1:-}"
+TYPE="${3:-note}"
+
+# Default tag is type-aware if not provided
+if [[ -n "${2:-}" ]]; then
+  TAG="$2"
+elif [[ "$TYPE" == arch || "$TYPE" == architecture ]]; then
+  TAG="architecture"
+else
+  TAG="field note"
+fi
+
+if [[ -z "$TITLE" ]]; then
+  echo "usage: make post TITLE=\"my title\" TAG=\"debugging\""
+  echo "       make post TITLE=\"my essay\" TAG=\"architecture\" TYPE=arch"
+  exit 1
+fi
+
+# Derive slug: lowercase, strip non-alphanumeric, collapse hyphens
+SLUG=$(echo "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed 's/[^a-z0-9 ]//g' \
+  | tr ' ' '-' \
+  | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
+
+case "$TYPE" in
+  note)
+    SECTION="notes"
+    TEMPLATE="src/templates/note.mdx"
+    TITLE_PLACEHOLDER="Short, specific title describing the exact problem"
+    ;;
+  arch|architecture)
+    SECTION="architecture"
+    TEMPLATE="src/templates/architecture.mdx"
+    TITLE_PLACEHOLDER="The decision or system being described"
+    ;;
+  *)
+    echo "error: TYPE must be 'note' or 'arch'"
+    exit 1
+    ;;
+esac
+
+DEST="src/pages/${SECTION}/${SLUG}/index.mdx"
+
+if [[ -f "$DEST" ]]; then
+  echo "error: ${DEST} already exists"
+  exit 1
+fi
+
+mkdir -p "$(dirname "$DEST")"
+cp "$TEMPLATE" "$DEST"
+
+TODAY=$(date +%Y-%m-%d)
+
+# Substitute placeholders (macOS-compatible sed with no backup extension)
+sed -i '' "s|${TITLE_PLACEHOLDER}|${TITLE}|g" "$DEST"
+sed -i '' "s/YYYY-MM-DD/${TODAY}/" "$DEST"
+sed -i '' "s|tag: \"[^\"]*\"|tag: \"${TAG}\"|" "$DEST"
+
+echo ""
+echo "  created  ${DEST}"
+echo "  title    ${TITLE}"
+echo "  tag      ${TAG}"
+echo "  date     ${TODAY}"
+echo ""

--- a/src/templates/architecture.mdx
+++ b/src/templates/architecture.mdx
@@ -1,0 +1,47 @@
+import ArticleLayout from "@/layouts/ArticleLayout.astro";
+
+export const metadata = {
+  title: "The decision or system being described",
+  date: "YYYY-MM-DD",
+  tag: "architecture",
+  description: "What this essay argues or explains — one sentence.",
+};
+
+{/*
+  Checklist before publishing:
+  [ ] Title frames the decision, not just the component ("X as Y" or "Why we shaped X this way")
+  [ ] metadata.description describes what the essay argues or explains
+  [ ] metadata.tag matches the area: operator design · state systems · platform · reliability
+  [ ] Sections flow: context → constraint → decision → tradeoffs
+  [ ] No placeholder text remains
+*/}
+
+<ArticleLayout
+  title={metadata.title}
+  meta={`${metadata.date} · ${metadata.tag}`}
+  subtitle={metadata.description}
+  backHref="/architecture/"
+  backLabel="← architecture"
+>
+
+## Context
+
+{/* What is the system or problem space? What forces or constraints shaped this? Keep it tight. */}
+
+## The problem
+
+{/* What specifically needed a decision? What made this non-obvious? What were the competing options? */}
+
+## Design direction
+
+{/* What approach was chosen and why? Be direct — state the decision, then justify it. */}
+
+## Tradeoffs
+
+{/* What does this approach give up? What would make you revisit this decision? */}
+
+## Boundaries
+
+{/* Where does this design stop? What's explicitly out of scope? */}
+
+</ArticleLayout>

--- a/src/templates/note.mdx
+++ b/src/templates/note.mdx
@@ -1,0 +1,52 @@
+import ArticleLayout from "@/layouts/ArticleLayout.astro";
+
+export const metadata = {
+  title: "Short, specific title describing the exact problem",
+  date: "YYYY-MM-DD",
+  tag: "field note",
+  description: "One sentence. What does this note explain and why does it matter.",
+};
+
+{/*
+  Checklist before publishing:
+  [ ] Title is specific — describes the exact problem, not just the area
+  [ ] metadata.date is accurate (YYYY-MM-DD)
+  [ ] metadata.tag is one of: field note · debugging · security · architecture · platform
+  [ ] metadata.description is one sentence — states what the note explains
+  [ ] backHref/nextHref links are correct
+  [ ] No placeholder text remains
+*/}
+
+<ArticleLayout
+  title={metadata.title}
+  meta={`${metadata.date} · ${metadata.tag}`}
+  subtitle={metadata.description}
+  backHref="/notes/"
+  backLabel="← all notes"
+>
+
+## Background
+
+{/* What were you doing when you hit this? Give just enough context. One short paragraph. */}
+
+## What happened
+
+{/* Describe the symptom or error. Include the exact error message if there is one. */}
+
+```
+error message or log output here
+```
+
+## Why it happens
+
+{/* Root cause. One paragraph. Explain the mechanism, not just "X was wrong". */}
+
+## Fix
+
+{/* What resolved it. Be concrete — commands, config changes, file paths. */}
+
+```bash
+# commands here
+```
+
+</ArticleLayout>


### PR DESCRIPTION
## Summary

Replaces the untouched Astro starter kit boilerplate with a README that
reflects the actual project, and updates the repo description and homepage.

## Changes

- **README.md**: rewritten to cover stack, local dev commands, content
  structure, the `metadata` export convention for new posts, and CI overview
- **Repo description**: updated via GitHub API to
  "Platform engineering field notes, architecture essays, and project writeups."
