### PR TITLE
feat: add PR build previews via surge.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,18 +64,33 @@ jobs:
     timeout-minutes: 10
     permissions:
       pull-requests: write
+    env:
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
     steps:
+      - name: Check SURGE_TOKEN
+        id: check
+        run: |
+          if [ -z "$SURGE_TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SURGE_TOKEN secret not set — skipping preview deployment"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: steps.check.outputs.configured == 'true'
         with:
           name: dist
           path: dist/
 
       - name: Deploy to surge.sh
+        if: steps.check.outputs.configured == 'true'
         run: |
           npm install --global surge
-          surge ./dist viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+          surge ./dist viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token "$SURGE_TOKEN"
 
       - name: Post preview URL comment
+        if: steps.check.outputs.configured == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,56 @@ jobs:
           config: cspell.json
           strict: true
 
+  preview:
+    name: Deploy preview
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Deploy to surge.sh
+        run: |
+          npm install --global surge
+          surge ./dist viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Post preview URL comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const marker = '<!-- surge-preview -->';
+            const url = `https://viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh`;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const body = `${marker}\n### Preview deployed\n\n| | |\n|---|---|\n| **URL** | ${url} |\n| **Commit** | \`${sha}\` |`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
   audit:
     name: Lighthouse audit
     needs: build

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,40 @@
+name: Cleanup preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cleanup:
+    name: Teardown surge preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Teardown surge deployment
+        run: |
+          npm install --global surge
+          surge teardown viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Update preview comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const marker = '<!-- surge-preview -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: `${marker}\n### Preview removed\n\nThis PR has been closed and the preview deployment has been torn down.`,
+              });
+            }

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -13,13 +13,26 @@ jobs:
     name: Teardown surge preview
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
     steps:
+      - name: Check SURGE_TOKEN
+        id: check
+        run: |
+          if [ -z "$SURGE_TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Teardown surge deployment
+        if: steps.check.outputs.configured == 'true'
         run: |
           npm install --global surge
-          surge teardown viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+          surge teardown viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token "$SURGE_TOKEN"
 
       - name: Update preview comment
+        if: steps.check.outputs.configured == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Closes #19

Adds live preview deployments for every PR via surge.sh. Each PR gets a unique URL (`viniciusdc-blog-pr-N.surge.sh`) posted as a sticky comment that updates on each push and is torn down when the PR closes.

## Changes

### `.github/workflows/ci.yml`
- New `preview` job (runs after `build`): downloads the `dist` artifact, deploys to surge.sh, then creates-or-updates a single PR comment via `actions/github-script` using an HTML marker to avoid duplicate comments

### `.github/workflows/preview-cleanup.yml`
- New workflow triggered on `pull_request: types: [closed]`
- Tears down the surge deployment and updates the preview comment to indicate the preview was removed

## Before / After

```
# Before
PR merged — no preview, reviewer must build locally to check content changes

# After
PR opened → comment posted:
  Preview deployed
  URL     | https://viniciusdc-blog-pr-18.surge.sh
  Commit  | abc1234

PR closed → comment updated:
  Preview removed
```

## Setup required

Add a `SURGE_TOKEN` secret to the repository (Settings → Secrets → Actions).
Get the token with: `npx surge token`
