### PR TITLE
test: verify PR preview deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,18 +64,33 @@ jobs:
     timeout-minutes: 10
     permissions:
       pull-requests: write
+    env:
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
     steps:
+      - name: Check SURGE_TOKEN
+        id: check
+        run: |
+          if [ -z "$SURGE_TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SURGE_TOKEN secret not set — skipping preview deployment"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: steps.check.outputs.configured == 'true'
         with:
           name: dist
           path: dist/
 
       - name: Deploy to surge.sh
+        if: steps.check.outputs.configured == 'true'
         run: |
           npm install --global surge
-          surge ./dist viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+          surge ./dist viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token "$SURGE_TOKEN"
 
       - name: Post preview URL comment
+        if: steps.check.outputs.configured == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,56 @@ jobs:
           config: cspell.json
           strict: true
 
+  preview:
+    name: Deploy preview
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Deploy to surge.sh
+        run: |
+          npm install --global surge
+          surge ./dist viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Post preview URL comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const marker = '<!-- surge-preview -->';
+            const url = `https://viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh`;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const body = `${marker}\n### Preview deployed\n\n| | |\n|---|---|\n| **URL** | ${url} |\n| **Commit** | \`${sha}\` |`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
   audit:
     name: Lighthouse audit
     needs: build

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,40 @@
+name: Cleanup preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cleanup:
+    name: Teardown surge preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Teardown surge deployment
+        run: |
+          npm install --global surge
+          surge teardown viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Update preview comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const marker = '<!-- surge-preview -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: `${marker}\n### Preview removed\n\nThis PR has been closed and the preview deployment has been torn down.`,
+              });
+            }

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -13,13 +13,26 @@ jobs:
     name: Teardown surge preview
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
     steps:
+      - name: Check SURGE_TOKEN
+        id: check
+        run: |
+          if [ -z "$SURGE_TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Teardown surge deployment
+        if: steps.check.outputs.configured == 'true'
         run: |
           npm install --global surge
-          surge teardown viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+          surge teardown viniciusdc-blog-pr-${{ github.event.pull_request.number }}.surge.sh --token "$SURGE_TOKEN"
 
       - name: Update preview comment
+        if: steps.check.outputs.configured == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |

--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "cli", "sdk", "iac",
     "hostnames", "hostname",
     "networkidle",
+    "lockfiles", "lockfile", "frontmatter",
     "writeups", "write-ups",
     "hsts", "HSTS",
     "tlsoptions",

--- a/src/pages/notes/hello-astro/index.astro
+++ b/src/pages/notes/hello-astro/index.astro
@@ -1,0 +1,47 @@
+---
+export const metadata = {
+  title: "Migrating from Jekyll to Astro",
+  date: "2026-04-29",
+  tag: "field note",
+  description: "Why I replaced a Jekyll GitHub Pages blog with an Astro site and what the migration actually involved.",
+};
+
+import ArticleLayout from "@/layouts/ArticleLayout.astro";
+---
+
+<ArticleLayout
+  title={metadata.title}
+  meta={`${metadata.date} · ${metadata.tag}`}
+  subtitle={metadata.description}
+  backHref="/notes/"
+  backLabel="← all notes"
+>
+
+## Why
+
+The Jekyll blog worked fine for static posts but the Ruby toolchain was becoming a
+maintenance burden — Bundler, `rbenv`, gem lockfiles, and a parade of Dependabot bumps
+for gems the site barely used. Every new machine required setting up a Ruby environment
+just to preview a post.
+
+Astro runs on Node, which is already present everywhere, and the component model fits
+how I actually think about pages: layout once, content separately.
+
+## What changed
+
+The site is now fully static Astro with `.astro` pages and `export const metadata`
+instead of YAML frontmatter. Content discovery uses `import.meta.glob` rather than
+Jekyll's collection system, so adding a new note means dropping a file in the right
+directory — no config changes needed.
+
+GitHub Pages now deploys via a workflow artifact (`actions/upload-pages-artifact` +
+`actions/deploy-pages`) instead of building from a branch. The `gh-pages` branch, which
+previously held both source and the Jekyll build output depending on the era, was renamed
+to `main`.
+
+## What stayed the same
+
+The domain, the URL structure, and the overall design. The goal was to remove friction
+from the authoring workflow, not redesign the site.
+
+</ArticleLayout>


### PR DESCRIPTION
Test PR to verify the surge.sh preview deployment added in #20.

The preview job runs on this PR's branch which includes the workflow changes, so the deploy should trigger and post a comment with a live URL — assuming `SURGE_TOKEN` is configured.

This note can be kept or dropped after the preview is confirmed working.
