### PR TITLE
ci: add Dependabot cooldown, auto-merge, and OSV-Scanner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: weekly
     commit-message:
       prefix: "ci"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 1
+      semver-major-days: 3
+      semver-minor-days: 2
+      semver-patch-days: 1
 
   - package-ecosystem: npm
     directory: /
@@ -13,6 +20,16 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore"
+    labels:
+      - "dependencies"
+      - "javascript"
+    # Supply-chain soak: wait N days after a release before opening a PR, so
+    # registry takedowns / CVEs / follow-up patches have time to surface.
+    cooldown:
+      default-days: 1
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
     ignore:
       # Puppeteer ships a bundled Chromium — major bumps need manual testing
       - dependency-name: puppeteer

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for patch/minor
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,18 @@
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-pr:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      actions: read
+      contents: read
+      security-events: write


### PR DESCRIPTION
## Summary

Adds a supply-chain soak window for Dependabot PRs and auto-merge for safe updates.

- **Cooldown in `.github/dependabot.yml`** — Dependabot will no longer open a PR until a release is N days old. For npm: 1 day for patches, 3 days for minors, 7 days for majors. For GitHub Actions: 1/2/3 days. If a package is yanked, hijacked, or a CVE lands during the window, Dependabot either supersedes the PR with a newer version or never opens it.
- **`dependabot-auto-merge.yml`** — Enables GitHub auto-merge on Dependabot PRs for `semver-patch` and `semver-minor` updates only. Auto-merge waits for CI green; major bumps and Puppeteer (already ignored for majors) still require manual review. Uses `dependabot/fetch-metadata` to classify the update.
- **`osv-scanner.yml`** — Runs OSV-Scanner on every PR. Catches known-bad versions during the soak window (the 24h delay handles undisclosed compromises; OSV-Scanner handles already-disclosed ones).
- **Explicit labels** — `dependencies` (+ `javascript` for npm) are now declared in `dependabot.yml` rather than relying on Dependabot defaults.

## Test plan (this PR)

- [x] CI is green — YAML syntax for all three files validates (`Build`, `Spell check`, `Lighthouse audit` pass).
- [x] `OSV-Scanner / scan-pr` runs on this PR and reports green (this is the workflow exercising itself).
- [x] `Dependabot auto-merge` workflow does NOT run on this PR (skipped — gated on `github.actor == 'dependabot[bot]'`).

## Follow-up

Verification of the actual cooldown + auto-merge behavior requires a real Dependabot PR cycle and one-time repo-settings flips, tracked in #37.