### PR TITLE
fix: drop unsupported cooldown fields from github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,10 @@ updates:
       prefix: "ci"
     labels:
       - "dependencies"
+    # GitHub Actions ecosystem only supports `default-days` in cooldown
+    # (Actions don't follow strict semver — most release single major tags).
     cooldown:
-      default-days: 1
-      semver-major-days: 3
-      semver-minor-days: 2
-      semver-patch-days: 1
+      default-days: 2
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
## Summary

Follow-up to #36. The `cooldown` block on the `github-actions` ecosystem only accepts `default-days` — `semver-major-days`, `semver-minor-days`, and `semver-patch-days` are npm-only. The validator rejected the config on both #18 and #22 after their rebases pulled in main.

- Drops the three unsupported fields from the github-actions block.
- Settles on `default-days: 2` for that ecosystem (Actions are SHA-pinned in this repo anyway, so the soak is mostly belt-and-suspenders).
- Leaves the npm block untouched — per-semver cooldown there is valid.

## Test plan

- [ ] CI green (`.github/dependabot.yml` validator now passes).
- [ ] After merge, re-rebase #22 and #18 to clear their `.github/dependabot.yml` red check.