### PR TITLE
chore: retry enable-auto-merge on transient GitHub 504s

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,7 +20,18 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
+        # Retry with backoff: GitHub's GraphQL API occasionally returns a 504
+        # ("Unicorn!" page) on enableAutoMerge — a transient that resolves on retry.
+        run: |
+          for attempt in 1 2 3; do
+            if gh pr merge --auto --squash "$PR_URL"; then
+              exit 0
+            fi
+            echo "::warning::Attempt $attempt to enable auto-merge failed; retrying in $((attempt * 5))s" >&2
+            sleep $((attempt * 5))
+          done
+          echo "::error::Failed to enable auto-merge after 3 attempts" >&2
+          exit 1
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #36 and the failed run on #31 (https://github.com/viniciusdc/viniciusdc.github.io/actions/runs/25673595855/job/75365171501).

The previous run on #31 failed when GitHub's GraphQL API returned a 504 Gateway Timeout (the "Unicorn!" error page) during the `gh pr merge --auto --squash` call. The workflow had no retry, so the transient left the PR stuck without auto-merge — I had to enable it manually afterward.

Wraps the call in a 3-attempt loop with linear backoff (5s → 10s → 15s, total max wait 30s) and emits `::warning::` / `::error::` annotations so the run page shows the retry behavior clearly.

## Test plan

- [ ] CI green.
- [ ] The next Dependabot patch/minor PR after merge enables auto-merge on the first attempt (the steady-state path is unchanged).
- [ ] If a 504 ever recurs, the run will show a `::warning::` annotation but still succeed.