### PR TITLE
chore: friendlier Makefile (help, pre-flight, clean, doctor, banners)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,81 @@
-.PHONY: install dev build preview check banner post
+.PHONY: help install dev build preview check banner post clean doctor _check_pixi
 
-# Local dev runs through a pixi-managed Node 22 env (conda-forge) so
-# the system Node version doesn't matter. On first `make <target>`,
-# pixi solves and installs the env into `.pixi/` (gitignored).
-#
-# Requires pixi: https://pixi.sh — `curl -fsSL https://pixi.sh/install.sh | bash`
+# Bare `make` shows the help.
+.DEFAULT_GOAL := help
+
+# Local dev runs through a pixi-managed Node 22 env (conda-forge) so the
+# system Node version doesn't matter. On first `make <target>`, pixi solves
+# and installs the env into `.pixi/` (gitignored). Pixi install: https://pixi.sh
+
+# ── help ──────────────────────────────────────────────────────────────────────
+
+help:  ## Show this help.
+	@printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"
+	@awk 'BEGIN {FS = ":.*?##"} \
+		/^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' \
+		$(MAKEFILE_LIST)
+	@printf "\n"
+
+# ── pre-flight ────────────────────────────────────────────────────────────────
+
+# Internal: every pixi-using target depends on this. Fails fast with a useful
+# pointer instead of letting `pixi` itself report "command not found".
+_check_pixi:
+	@command -v pixi >/dev/null 2>&1 || { \
+		printf "\033[31merror:\033[0m \`pixi\` is not on PATH.\n"; \
+		printf "  Install pixi: https://pixi.sh/latest/installation/\n"; \
+		printf "  Then re-run \`make %s\`.\n" "$(MAKECMDGOALS)"; \
+		exit 1; \
+	}
 
 # ── environment ───────────────────────────────────────────────────────────────
 
-install:
-	pixi run install
+install: _check_pixi  ## Install npm dependencies inside the pixi env.
+	@printf "\033[1;36m==>\033[0m install: solving env + npm install\n"
+	@pixi run install
 
-dev:
-	pixi run dev
+dev: _check_pixi  ## Start the Astro dev server at http://localhost:4321.
+	@printf "\033[1;36m==>\033[0m dev: starting Astro dev server at http://localhost:4321\n"
+	@pixi run dev
 
-build:
-	pixi run build
+build: _check_pixi  ## Build the production site to dist/.
+	@printf "\033[1;36m==>\033[0m build: building static site to dist/\n"
+	@pixi run build
 
-preview:
-	pixi run preview
+preview: _check_pixi  ## Serve dist/ locally to preview the production build.
+	@printf "\033[1;36m==>\033[0m preview: serving dist/\n"
+	@pixi run preview
 
-check:
-	pixi run check
+check: _check_pixi  ## Run type-check and spell-check.
+	@printf "\033[1;36m==>\033[0m check: type-check + spell-check\n"
+	@pixi run check
+
+doctor: _check_pixi  ## Print resolved versions of pixi, node, and npm.
+	@printf "\033[1;36m==>\033[0m doctor: environment versions\n"
+	@printf "  pixi : %s\n" "$$(pixi --version 2>/dev/null | awk '{print $$2}')"
+	@printf "  node : %s\n" "$$(pixi run --quiet node --version 2>/dev/null)"
+	@printf "  npm  : %s\n" "$$(pixi run --quiet npm --version 2>/dev/null)"
+
+clean:  ## Remove build artifacts and caches (dist/, .astro/, .pixi/, node_modules/).
+	@printf "\033[1;36m==>\033[0m clean: removing dist/, .astro/, .pixi/, node_modules/\n"
+	@rm -rf dist .astro .pixi node_modules
 
 # ── assets ────────────────────────────────────────────────────────────────────
 
-banner:
-	pixi run banner
+banner: _check_pixi  ## Regenerate .github/banner.svg.
+	@printf "\033[1;36m==>\033[0m banner: regenerating .github/banner.svg\n"
+	@pixi run banner
 
 # ── content ───────────────────────────────────────────────────────────────────
 #
 #   make post TITLE="k3s coredns loop"                   → notes post, tag=field note
 #   make post TITLE="k3s coredns loop" TAG="debugging"   → notes post, tag=debugging
-#   make post TITLE="operator ownership" TYPE=arch        → architecture essay
+#   make post TITLE="operator ownership" TYPE=arch       → architecture essay
 
-post:
+post: _check_pixi  ## Scaffold a new post — requires TITLE; optional TAG and TYPE=note|arch.
 ifndef TITLE
-	$(error TITLE is required.  make post TITLE="my title" TAG="debugging" TYPE=note)
+	$(error TITLE is required.  Example: make post TITLE="my title" TAG="debugging" TYPE=note|arch)
 endif
+	@printf "\033[1;36m==>\033[0m post: scaffolding \"%s\"\n" "$(TITLE)"
 	@chmod +x scripts/new-post.sh
 	@pixi run node scripts/new-post.sh "$(TITLE)" "$(or $(TAG),field note)" "$(or $(TYPE),note)"


### PR DESCRIPTION
Closes #44. Stacks on #43 — base is `chore/pixi-env-for-local-dev`, will retarget to `main` once #43 lands.

## Summary

A small polish pass on the Makefile so a fresh checkout is more welcoming than "you got a command-not-found error."

- **Default to help.** `make` with no args now runs `make help`, which auto-generates a target list from `## description` comments. No more silent no-op.
- **Pixi pre-flight check.** A `_check_pixi` phony prereq fails fast with a friendly install pointer when pixi isn't on PATH, instead of letting every pixi-using target die with `pixi: command not found`.
- **`make clean`.** Removes `dist/`, `.astro/`, `.pixi/`, `node_modules/` — for when state is corrupted or you want a real fresh start.
- **`make doctor`.** Prints resolved versions of pixi, Node, and npm — useful when something is wedged and you need to know which Node is actually running.
- **`==>` banners.** Each target echoes a single colored banner line before doing its work so the output isn't an undifferentiated wall of npm log.
- **`make post` error message** now shows the accepted `TYPE` values (`note|arch`) instead of only naming the flag.

## Things deliberately skipped from #44

- `make open` to launch the dev server in a browser — risks opening a dead URL if dev isn't running yet, and the URL is already printed by `make dev`. Not worth the platform-detection logic.
- `tput`-based colors. Using inline ANSI escape codes instead — same effect, no extra dependency, works on every modern terminal we care about.

## Test plan

- [x] `make` (no args) renders the help block locally.
- [x] `make doctor` prints versions (pixi 0.59.0, node v22.x, npm 11.x).
- [x] `make post` without `TITLE` shows the friendlier error.
- [x] `make check` still routes through pixi.
- [ ] Reviewer confirms `make` works on a clean clone without pixi installed and shows the friendly pointer.