### PR TITLE
feat: KaTeX math rendering + image lightbox for articles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,11 +2,13 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import tailwindcss from '@tailwindcss/vite';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
 import path from 'path';
 
 export default defineConfig({
   site: 'https://viniciusdc.github.io',
-  integrations: [mdx()],
+  integrations: [mdx({ remarkPlugins: [remarkMath], rehypePlugins: [rehypeKatex] })],
   devToolbar: { enabled: false },
   vite: {
     plugins: [tailwindcss()],

--- a/cspell.json
+++ b/cspell.json
@@ -10,10 +10,11 @@
     "keycloak", "oidc", "oauth", "saml", "jwt", "jwks",
     "fastapi", "pydantic", "scrapy", "uvicorn",
     "vinicius", "cerutti", "Ceture", "viniciusdc", "Catarina", "UFSC",
-    "astro", "tailwind", "shadcn", "fontsource", "lhci",
+    "astro", "tailwind", "shadcn", "fontsource", "lhci", "lightbox",
     "woff", "woff2", "oklch", "rgb", "rgba", "hsl",
     "clamp", "minmax", "prefers",
     "nebari", "jmespath", "snistrict",
+    "journalctl", "systemd",
     "firewalld", "libvirt", "vagrantfile",
     "syscall", "seccomp", "apparmor", "selinux",
     "etcd", "kube", "kube-proxy", "coredns",
@@ -39,9 +40,11 @@
     "semidefinite", "semidefiniteness",
     "Barzilai", "Borwein",
     "nonmonotone", "GLL",
-    "Hessian", "quasi-Newton",
+    "Hessian", "quasi-Newton", "eigencomponents",
+    "mathbb", "mathbf", "mathcal", "bigl", "bigr",
     "NMR", "PDB", "crystallography",
-    "Gram"
+    "Gram", "Schoenberg", "Wüthrich", "ChimeraX", "PIBIC", "RMSD", "MDE", "RCSB",
+    "PGDm", "Gonçalves", "Birgin", "Martínez", "Raydan", "UCSF"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "@fontsource-variable/lora": "^5.2.8",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.3.3",
+        "katex": "^0.16.47",
+        "rehype-katex": "^7.0.1",
+        "remark-math": "^6.0.0",
         "tailwindcss": "^4.2.4"
       },
       "devDependencies": {
@@ -4429,6 +4432,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -7713,6 +7722,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
@@ -7725,6 +7749,22 @@
         "parse5": "^7.0.0",
         "vfile": "^6.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8614,6 +8654,31 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -9249,6 +9314,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
@@ -9621,6 +9705,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -11361,44 +11464,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11608,6 +11673,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -11679,6 +11763,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "@fontsource-variable/lora": "^5.2.8",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.3.3",
+    "katex": "^0.16.47",
+    "rehype-katex": "^7.0.1",
+    "remark-math": "^6.0.0",
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {

--- a/src/components/ui/ImageLightbox.astro
+++ b/src/components/ui/ImageLightbox.astro
@@ -1,0 +1,110 @@
+---
+/**
+ * Click-to-zoom modal for figure images inside .article-content.
+ *
+ * Drop this component anywhere on a page that uses ArticleLayout — it'll
+ * find every `.article-content figure img`, give it a zoom cursor, and
+ * open a full-screen modal with the figcaption on click.
+ *
+ * Closes on backdrop click, the close button, or Escape. No dependencies.
+ */
+---
+
+<div id="lightbox" aria-modal="true" role="dialog" aria-label="Image preview">
+  <button id="lightbox-close" aria-label="Close">✕</button>
+  <img id="lightbox-img" src="" alt="" />
+  <p id="lightbox-caption"></p>
+</div>
+
+<script>
+  const lightbox = document.getElementById('lightbox');
+  const lbImg    = document.getElementById('lightbox-img') as HTMLImageElement | null;
+  const lbCap    = document.getElementById('lightbox-caption');
+  const lbClose  = document.getElementById('lightbox-close');
+
+  if (lightbox && lbImg && lbCap && lbClose) {
+    document.querySelectorAll<HTMLImageElement>('.article-content figure img').forEach(img => {
+      img.style.cursor = 'zoom-in';
+      img.addEventListener('click', () => {
+        lbImg.src = img.src;
+        lbImg.alt = img.alt;
+        const cap = img.closest('figure')?.querySelector('figcaption')?.textContent ?? '';
+        lbCap.textContent = cap;
+        lbCap.style.display = cap ? '' : 'none';
+        lightbox.classList.add('open');
+        document.body.style.overflow = 'hidden';
+      });
+    });
+
+    const close = () => {
+      lightbox.classList.remove('open');
+      document.body.style.overflow = '';
+    };
+
+    lbClose.addEventListener('click', close);
+    lightbox.addEventListener('click', e => { if (e.target === lightbox) close(); });
+    document.addEventListener('keydown', e => { if (e.key === 'Escape') close(); });
+  }
+</script>
+
+<style>
+  #lightbox {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: rgba(20, 17, 13, 0.94);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+  }
+  #lightbox.open { display: flex; }
+
+  #lightbox-img {
+    max-width: min(1100px, 92vw);
+    max-height: 88vh;
+    width: auto;
+    height: auto;
+    border-radius: 10px;
+    border: 1px solid var(--border-strong);
+    object-fit: contain;
+    cursor: zoom-out;
+  }
+
+  #lightbox-caption {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: var(--faint);
+    max-width: min(1100px, 92vw);
+    text-align: center;
+    margin: 0;
+  }
+
+  #lightbox-close {
+    position: absolute;
+    top: 20px;
+    right: 24px;
+    background: none;
+    border: 1px solid var(--border-strong);
+    color: var(--muted-foreground);
+    font-size: 14px;
+    line-height: 1;
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 120ms, border-color 120ms;
+  }
+  #lightbox-close:hover {
+    color: var(--foreground);
+    border-color: var(--foreground);
+  }
+</style>

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 import PageRule from "@/components/ui/PageRule.astro";
+import ImageLightbox from "@/components/ui/ImageLightbox.astro";
 
 interface Props {
   title: string;
@@ -17,6 +18,7 @@ const { title, description, meta, subtitle, backHref, backLabel, nextHref, nextL
 ---
 
 <Layout title={`${title} — Vinicius's notebook`} description={description ?? subtitle}>
+  <ImageLightbox />
   <div class="article-shell">
     <header class="article-header">
       <p class="article-meta">{meta}</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "@fontsource-variable/geist";
 @import "@fontsource-variable/lora";
+@import "katex/dist/katex.min.css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -103,3 +104,12 @@
         body::before { opacity: 0.025; }
     }
 }
+
+/* KaTeX — dark-theme overrides so math sits in the warm palette
+   instead of KaTeX's default black/white. */
+.katex { color: inherit; font-size: 1.05em; }
+.katex-display { color: var(--foreground); overflow-x: auto; padding: 0.25em 0; }
+.katex-display > .katex { color: var(--foreground); }
+.katex .mord, .katex .mrel, .katex .mbin, .katex .mop,
+.katex .mopen, .katex .mclose, .katex .mpunct { color: inherit; }
+.katex .mfrac .frac-line { border-bottom-color: currentColor; }


### PR DESCRIPTION
## Summary

Schema/config support that #22 (protein essay) and #18 (k8s benchmark note) both depend on. Extracted into a single PR so the content PRs can be reduced to just their prose.

After this lands, both #22 and #18 rebase to drop their schema/config commits and become pure prose+figure PRs.

## What's in it

**KaTeX math rendering**
- Wire `remark-math` + `rehype-katex` into the MDX integration in `astro.config.mjs` so equations render at build time (no client JS).
- Add `katex`, `rehype-katex`, `remark-math` as deps.
- Import `katex/dist/katex.min.css` in `global.css` with a small dark-theme override block so math sits in the warm palette instead of black/white.

**Image lightbox**
- Extract the lightbox HTML/CSS/JS from the inline form in #22 into `src/components/ui/ImageLightbox.astro` — a self-contained component.
- Include once in `ArticleLayout`. Any `.article-content figure img` now gets click-to-zoom (close on backdrop / X button / Escape, no deps).
- Max sizes tuned for readability: 1100px / 88vh.

**cspell.json**
- Vocabulary the pending content PRs need so they pass spell-check after rebasing down to pure content:
  - K8s benchmark: \`journalctl\`, \`systemd\`
  - LaTeX/math vocabulary used by the protein essay: \`lightbox\`, \`eigencomponents\`, \`mathbb\`, \`mathbf\`, \`mathcal\`, \`bigl\`, \`bigr\`
  - Names from the protein essay: \`Schoenberg\`, \`Wüthrich\`, \`ChimeraX\`, \`PIBIC\`, \`RMSD\`, \`MDE\`, \`RCSB\`, \`PGDm\`, \`Gonçalves\`, \`Birgin\`, \`Martínez\`, \`Raydan\`, \`UCSF\`

## What's not in it

- The actual posts (#22's protein essay and #18's k8s benchmark stay in their respective PRs)
- ArticleLayout text/heading styling fixes that were in #18 — those are superseded by the design rewrite already on main
- `.nvmrc` from #18 — superseded by the pixi pin to \`nodejs = "22.*"\` already on main

## Test plan

- [x] \`pixi run npm run build\` produces dist/ cleanly with the KaTeX CSS bundled.
- [x] \`pixi run npm run spell\` is green with the new entries.
- [ ] CI green.
- [ ] After merge: rebase #22 and #18 to drop their schema/config commits — they should reduce to just MDX content + figure assets.