### PR TITLE
design: drop the scribble tilt on the right-now margin note

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -158,9 +158,6 @@ const hasNow = nowSource.trim().length > 0;
     padding: 6px 0 6px 18px;
     margin: 0;
     max-width: 56ch;
-    /* a slightly more visible imperfection — leans 0.7° as if scribbled */
-    transform: rotate(-0.7deg);
-    transform-origin: left center;
   }
   .margin-label {
     display: block;


### PR DESCRIPTION
The \`-0.7deg\` rotation I added to \`.hero-margin\` was meant to feel like a scribbled-in margin note. In practice it just reads as *"is the page actually tilted?"* — caught when reviewing the deployed homepage.

Reverting the rotation. The accent-coloured border and italic serif still carry the margin-note register without making readers question their monitor.

## Test plan

- [x] \`pixi run npm run build\` — 8 pages, green.