### PR TITLE
chore: add local palette preview tool

### DIFF
--- a/palette-preview.html
+++ b/palette-preview.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en" data-palette="current">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Palette preview — vinicius.dev</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Inter:wght@400;500;600;700&display=swap" />
+  <style>
+    /* ── palettes ────────────────────────────────────────────────────────── */
+    :root {
+      --font-serif: 'Lora', Georgia, serif;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+    [data-palette="current"] {
+      --background: #1a1612;
+      --foreground: #ede0c4;
+      --card: #241d16;
+      --muted-foreground: #c8b395;
+      --accent: #d4a261;
+      --border: rgba(212, 162, 97, 0.13);
+      --border-strong: rgba(212, 162, 97, 0.24);
+      --faint: #96866d;
+      --accent-soft: rgba(212, 162, 97, 0.10);
+      --code-bg: #110d09;
+      --code-fg: #e2bd83;
+    }
+    [data-palette="m3"] {
+      --background: #121212;
+      --foreground: #e6e1e5;
+      --card: #1d1b20;
+      --muted-foreground: #cac4d0;
+      --accent: #d0bcff;
+      --border: rgba(255, 255, 255, 0.08);
+      --border-strong: rgba(255, 255, 255, 0.16);
+      --faint: #79747e;
+      --accent-soft: rgba(208, 188, 255, 0.10);
+      --code-bg: #1d1b20;
+      --code-fg: #ccc2dc;
+    }
+    [data-palette="palenight"] {
+      --background: #292d3e;
+      --foreground: #eeffff;
+      --card: #353a4f;
+      --muted-foreground: #b2bef3;
+      --accent: #c792ea;
+      --border: rgba(255, 255, 255, 0.06);
+      --border-strong: rgba(255, 255, 255, 0.14);
+      --faint: #676e95;
+      --accent-soft: rgba(199, 146, 234, 0.12);
+      --code-bg: #1f2233;
+      --code-fg: #ffcb6b;
+    }
+    [data-palette="ocean"] {
+      --background: #0f111a;
+      --foreground: #d0d6e3;
+      --card: #181a25;
+      --muted-foreground: #8a9ab5;
+      --accent: #82aaff;
+      --border: rgba(255, 255, 255, 0.06);
+      --border-strong: rgba(255, 255, 255, 0.14);
+      --faint: #555a73;
+      --accent-soft: rgba(130, 170, 255, 0.10);
+      --code-bg: #090b10;
+      --code-fg: #c3e88d;
+    }
+    [data-palette="warm-leaning"] {
+      --background: #181818;
+      --foreground: #e8e2d3;
+      --card: #222020;
+      --muted-foreground: #b8a98e;
+      --accent: #d4a261;
+      --border: rgba(212, 162, 97, 0.10);
+      --border-strong: rgba(212, 162, 97, 0.20);
+      --faint: #7a7060;
+      --accent-soft: rgba(212, 162, 97, 0.10);
+      --code-bg: #0e0e0e;
+      --code-fg: #e2bd83;
+    }
+    /* Hybrids — Ocean's depth + warm-leaning's personality */
+    [data-palette="ocean-caramel"] {
+      /* Ocean surfaces, caramel accent + slightly warmer foreground */
+      --background: #0f111a;
+      --foreground: #d8d3c2;
+      --card: #181a25;
+      --muted-foreground: #a8a08c;
+      --accent: #d4a261;
+      --border: rgba(212, 162, 97, 0.10);
+      --border-strong: rgba(212, 162, 97, 0.20);
+      --faint: #6a6859;
+      --accent-soft: rgba(212, 162, 97, 0.10);
+      --code-bg: #090b10;
+      --code-fg: #e2bd83;
+    }
+    [data-palette="warm-midnight"] {
+      /* Deeper than warm-leaning, still tonally warm */
+      --background: #131210;
+      --foreground: #e8e2d3;
+      --card: #1d1c1a;
+      --muted-foreground: #b8a98e;
+      --accent: #d4a261;
+      --border: rgba(212, 162, 97, 0.10);
+      --border-strong: rgba(212, 162, 97, 0.20);
+      --faint: #7a7060;
+      --accent-soft: rgba(212, 162, 97, 0.10);
+      --code-bg: #0a0908;
+      --code-fg: #e2bd83;
+    }
+
+    /* ── base ─────────────────────────────────────────────────────────────── */
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--background);
+      color: var(--foreground);
+      font-family: var(--font-serif);
+      transition: background 200ms ease, color 200ms ease;
+      min-height: 100vh;
+    }
+    a { color: var(--accent); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+
+    /* ── toggle bar ───────────────────────────────────────────────────────── */
+    .toggle-bar {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+      padding: 12px 20px;
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      align-items: center;
+      font-family: var(--font-sans);
+      font-size: 13px;
+    }
+    .toggle-bar .label {
+      color: var(--faint);
+      font-family: var(--font-mono);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      margin-right: 8px;
+    }
+    .toggle-bar button {
+      background: transparent;
+      border: 1px solid var(--border-strong);
+      color: var(--muted-foreground);
+      padding: 6px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: inherit;
+      transition: all 140ms ease;
+    }
+    .toggle-bar button:hover { color: var(--foreground); border-color: var(--foreground); }
+    .toggle-bar button.active {
+      background: var(--accent-soft);
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+    .toggle-bar .swatches { display: flex; gap: 6px; margin-left: auto; align-items: center; }
+    .toggle-bar .swatch {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      border: 1px solid var(--border-strong);
+    }
+
+    /* ── nav ──────────────────────────────────────────────────────────────── */
+    nav.site {
+      border-bottom: 1px solid var(--border);
+      background: var(--background);
+    }
+    nav.site .inner {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 18px 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .brand {
+      font-family: var(--font-serif);
+      font-style: italic;
+      font-size: 19px;
+      color: var(--foreground);
+    }
+    .brand-dev { color: var(--accent); }
+    .nav-links {
+      display: flex;
+      gap: 22px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+    }
+    .nav-links a { color: var(--muted-foreground); text-decoration: none; }
+    .nav-links a:hover { color: var(--foreground); }
+
+    /* ── article ──────────────────────────────────────────────────────────── */
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 60px 20px 80px;
+    }
+    .dateline {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--accent);
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      margin: 0 0 28px;
+    }
+    .hero-greet {
+      font-family: var(--font-serif);
+      font-style: italic;
+      font-size: 34px;
+      font-weight: 500;
+      line-height: 1.15;
+      letter-spacing: -0.01em;
+      color: var(--foreground);
+      margin: 0 0 22px;
+    }
+    .hero-copy {
+      font-family: var(--font-serif);
+      font-size: 19px;
+      line-height: 1.7;
+      color: var(--foreground);
+      margin: 0 0 28px;
+      max-width: 60ch;
+    }
+    .hero-margin {
+      font-family: var(--font-serif);
+      font-size: 15px;
+      font-style: italic;
+      line-height: 1.65;
+      color: var(--muted-foreground);
+      border-left: 2px solid var(--accent);
+      padding: 8px 0 8px 18px;
+      max-width: 56ch;
+      margin: 0;
+    }
+    .margin-label {
+      display: block;
+      font-family: var(--font-mono);
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--accent);
+      font-style: normal;
+      margin-bottom: 4px;
+    }
+
+    /* page-rule (Q.E.D. dots) */
+    .page-rule {
+      padding: 42px 0 30px;
+      color: var(--faint);
+      opacity: 0.55;
+    }
+    .page-rule svg { display: block; width: 84px; height: 6px; margin: 0 auto; }
+
+    /* entry list */
+    .recent-label {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--accent);
+      margin: 0 0 24px;
+    }
+    .entry {
+      display: block;
+      padding: 16px 14px;
+      margin: 0 -14px 6px;
+      border-radius: 8px;
+      text-decoration: none;
+      color: inherit;
+      transition: background 180ms ease;
+    }
+    .entry:hover {
+      background: var(--accent-soft);
+    }
+    .entry-meta {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--faint);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      margin: 0 0 4px;
+    }
+    .entry-title {
+      font-family: var(--font-sans);
+      font-size: 19px;
+      font-weight: 600;
+      line-height: 1.3;
+      letter-spacing: -0.01em;
+      color: var(--foreground);
+      margin: 0 0 4px;
+    }
+    .entry-desc {
+      font-family: var(--font-serif);
+      font-size: 16px;
+      line-height: 1.55;
+      color: var(--muted-foreground);
+      margin: 0;
+    }
+
+    /* code block sample */
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 14px 18px;
+      overflow-x: auto;
+      margin: 24px 0;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--foreground);
+    }
+    code:not(pre code) {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      color: var(--code-fg);
+      background: var(--accent-soft);
+      padding: 1px 5px;
+      border-radius: 4px;
+    }
+
+    /* h2 sample */
+    h2 {
+      font-family: var(--font-sans);
+      font-size: 24px;
+      font-weight: 650;
+      letter-spacing: -0.02em;
+      color: var(--foreground);
+      margin: 36px 0 14px;
+    }
+  </style>
+</head>
+<body>
+  <div class="toggle-bar">
+    <span class="label">palette</span>
+    <button data-palette="current" class="active">current — warm coffee</button>
+    <button data-palette="m3">M3 — canonical</button>
+    <button data-palette="palenight">Palenight</button>
+    <button data-palette="ocean">Ocean</button>
+    <button data-palette="warm-leaning">warm-leaning</button>
+    <button data-palette="ocean-caramel">Ocean + caramel</button>
+    <button data-palette="warm-midnight">warm midnight</button>
+    <div class="swatches" aria-hidden="true">
+      <span class="swatch" id="sw-bg" title="background"></span>
+      <span class="swatch" id="sw-fg" title="foreground"></span>
+      <span class="swatch" id="sw-accent" title="accent"></span>
+    </div>
+  </div>
+
+  <nav class="site">
+    <div class="inner">
+      <a href="#" class="brand">vinicius<span class="brand-dev">.dev</span></a>
+      <div class="nav-links">
+        <a href="#">writing</a>
+        <a href="#">projects</a>
+        <a href="#">about</a>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <p class="dateline">May 2026 — somewhere between calls</p>
+
+    <p class="hero-greet">This is where I keep what I'm thinking about.</p>
+
+    <p class="hero-copy">
+      It tends to be wide — Kubernetes one week, an AI paper the next,
+      sometimes math or design or a game. I'd rather write a little badly
+      and find out what I think than write a lot polished and find I had
+      nothing to say.
+    </p>
+
+    <aside class="hero-margin">
+      <span class="margin-label">right now</span>
+      Bare-metal K3s and the TLS trust chains that surround it. Catching up
+      on operator patterns, getting more confident in Go.
+    </aside>
+
+    <div class="page-rule" aria-hidden="true">
+      <svg viewBox="0 0 60 6" preserveAspectRatio="xMidYMid meet">
+        <rect x="0" y="0" width="6" height="6" fill="currentColor"/>
+        <rect x="27" y="0" width="6" height="6" fill="currentColor"/>
+        <rect x="54" y="0" width="6" height="6" fill="currentColor"/>
+      </svg>
+    </div>
+
+    <h2 class="recent-label">recent</h2>
+
+    <a href="#" class="entry">
+      <p class="entry-meta">2026-05-18 · meta</p>
+      <h3 class="entry-title">Beginning again</h3>
+      <p class="entry-desc">Notes on starting a notebook — what's here, what isn't, what I'm trying not to do.</p>
+    </a>
+
+    <a href="#" class="entry">
+      <p class="entry-meta">system · archived</p>
+      <h3 class="entry-title">Conda-forge auto-tick bot — version-update microservice</h3>
+      <p class="entry-desc">Split the conda-forge auto-tick bot's version-update cron job into its own microservice. My GSoC 2020 project with NumFOCUS.</p>
+    </a>
+
+    <h2>How code reads in this palette</h2>
+
+    <p style="font-family: var(--font-serif); font-size: 17px; line-height: 1.75; color: var(--foreground); max-width: 60ch;">
+      Inline <code>get_latest_version</code> calls and longer mentions of
+      <code>update_upstream_versions</code> appear in body text — code tint
+      should be distinct from prose without screaming for attention.
+    </p>
+
+    <pre>function injectDefaultLayout(layoutPath, includeDirs) {
+  return () =&gt; (_tree, file) =&gt; {
+    const fm = file?.data?.astro?.frontmatter;
+    if (!fm || fm.layout) return;
+    fm.layout = layoutPath;
+  };
+}</pre>
+  </main>
+
+  <script>
+    const buttons = document.querySelectorAll('[data-palette]');
+    const html = document.documentElement;
+    const swatches = {
+      bg: document.getElementById('sw-bg'),
+      fg: document.getElementById('sw-fg'),
+      accent: document.getElementById('sw-accent'),
+    };
+
+    function applyPalette(name) {
+      html.setAttribute('data-palette', name);
+      buttons.forEach(b => b.classList.toggle('active', b.dataset.palette === name));
+      // Update swatches by reading the computed CSS vars.
+      const cs = getComputedStyle(html);
+      swatches.bg.style.background = cs.getPropertyValue('--background');
+      swatches.fg.style.background = cs.getPropertyValue('--foreground');
+      swatches.accent.style.background = cs.getPropertyValue('--accent');
+    }
+
+    buttons.forEach(b => b.addEventListener('click', () => applyPalette(b.dataset.palette)));
+    applyPalette('current');
+
+    // Cycle palettes with the right arrow key for quick comparison.
+    document.addEventListener('keydown', e => {
+      if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+      const order = Array.from(buttons).map(b => b.dataset.palette);
+      const current = html.getAttribute('data-palette');
+      const i = order.indexOf(current);
+      const next = e.key === 'ArrowRight'
+        ? order[(i + 1) % order.length]
+        : order[(i - 1 + order.length) % order.length];
+      applyPalette(next);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
A self-contained \`palette-preview.html\` at the repo root that lets me compare candidate palettes side-by-side without rebuilding the site.

## How to use

\`\`\`sh
open palette-preview.html
\`\`\`

Toggle bar at the top swaps palettes live. Arrow keys ←/→ cycle through them for quick A/B comparison.

## What's in it

Currently included palettes:

- **current** — warm coffee, the deployed look
- **M3 — canonical** — Material Design 3 dark, purple primary + neutral grays
- **Palenight** — VS Code Material Palenight theme
- **Ocean** — deep navy with blue accent
- **warm-leaning** — neutral surfaces + warm caramel accent
- **Ocean + caramel** — Ocean's depth, current's accent, slightly warmer foreground
- **warm midnight** — deeper than warm-leaning, still tonally warm

## Scope

- Not wired into the build or deploy — purely a dev preview file at the root
- Self-contained: one HTML file, fonts via CDN, no dependencies
- 462 lines including all palette definitions inline