### PR TITLE
design: switch palette to Ocean + caramel

### DIFF
--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -258,7 +258,7 @@ const hasProjectMeta = Boolean(fm.label || fm.status || fm.repo || fm.demo);
     text-decoration-color: var(--accent);
   }
 
-  /* Code — caramel-tinted inline, warm dark for blocks */
+  /* Code — caramel-tinted inline, deep navy for blocks */
   .article-content :global(code) {
     color: #e2bd83;
     font-family: var(--font-mono);
@@ -272,11 +272,11 @@ const hasProjectMeta = Boolean(fm.label || fm.status || fm.repo || fm.demo);
     padding: 18px 20px;
     border: 1px solid var(--border);
     border-radius: 10px;
-    background: #110d09 !important;
+    background: #090b10 !important;
     margin: 24px 0;
   }
   .article-content :global(pre code) {
-    color: #e5dcc8;
+    color: #d8d3c2;
     font-size: 13px;
     background: none !important;
     padding: 0;
@@ -330,7 +330,7 @@ const hasProjectMeta = Boolean(fm.label || fm.status || fm.repo || fm.demo);
     letter-spacing: 0.06em;
     color: var(--faint);
     border-top: 1px solid var(--border);
-    background: rgba(26, 22, 18, 0.7);
+    background: rgba(15, 17, 26, 0.7);
   }
 
   /* Tables */

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,7 +35,7 @@ const nav = [
   <body>
     <nav
       class="sticky top-0 z-10 w-full border-b border-border text-[14px]"
-      style="background: rgba(26,22,18,0.82); backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px); color: var(--muted-foreground);"
+      style="background: rgba(15,17,26,0.82); backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px); color: var(--muted-foreground);"
       aria-label="Primary navigation"
     >
       <div class="w-[min(960px,calc(100%-44px))] mx-auto flex justify-between items-center gap-6 py-5">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -241,7 +241,7 @@ const hasNow = nowSource.trim().length > 0;
     transition: background 180ms ease, transform 180ms ease;
   }
   .entry-link:hover {
-    background: rgba(216, 166, 87, 0.04);
+    background: rgba(212, 162, 97, 0.04);
     transform: translateX(2px);
   }
   .entry-meta {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,7 +44,7 @@
     --secondary: #181a25;
     --secondary-foreground: #d8d3c2;
     --muted: #181a25;
-    --muted-foreground: #a8a08c; /* warm muted */
+    --muted-foreground: #b8a98e; /* warm muted — bumped for AAA contrast on navy */
     --accent: #d4a261;
     --accent-foreground: #0f111a;
     --destructive: oklch(0.704 0.191 22.216);
@@ -53,7 +53,7 @@
     --input: rgba(212, 162, 97, 0.10);
     --ring: #d4a261;
     --link: #d4a261;
-    --faint: #6a6859;
+    --faint: #928a78;            /* warm faint — needs ≥4.5:1 on the deep navy bg */
     --accent-soft: rgba(212, 162, 97, 0.10);
     --surface-raised: #1f2230;
     --radius: 0.625rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,32 +30,32 @@
     --radius-2xl: calc(var(--radius) * 1.8);
 }
 
-/* Always dark — dim café table at 7am, not stark espresso. */
+/* Always dark — deep navy surfaces, caramel accent. Ocean depth + warm signature. */
 :root {
     color-scheme: dark;
-    --background: #1a1612;      /* espresso, lifted */
-    --foreground: #ede0c4;      /* foam cream */
-    --card: #241d16;            /* mocha */
-    --card-foreground: #ede0c4;
-    --popover: #2c2218;
-    --popover-foreground: #ede0c4;
-    --primary: #d4a261;         /* caramel — desaturated from #d8a657 */
-    --primary-foreground: #1a1612;
-    --secondary: #241d16;
-    --secondary-foreground: #ede0c4;
-    --muted: #241d16;
-    --muted-foreground: #c8b395; /* oat milk */
+    --background: #0f111a;      /* deep navy */
+    --foreground: #d8d3c2;      /* warm parchment, not cool slate */
+    --card: #181a25;            /* elevated navy */
+    --card-foreground: #d8d3c2;
+    --popover: #1f2230;
+    --popover-foreground: #d8d3c2;
+    --primary: #d4a261;         /* caramel */
+    --primary-foreground: #0f111a;
+    --secondary: #181a25;
+    --secondary-foreground: #d8d3c2;
+    --muted: #181a25;
+    --muted-foreground: #a8a08c; /* warm muted */
     --accent: #d4a261;
-    --accent-foreground: #1a1612;
+    --accent-foreground: #0f111a;
     --destructive: oklch(0.704 0.191 22.216);
-    --border: rgba(212, 162, 97, 0.13);
-    --border-strong: rgba(212, 162, 97, 0.24);
-    --input: rgba(212, 162, 97, 0.13);
+    --border: rgba(212, 162, 97, 0.10);
+    --border-strong: rgba(212, 162, 97, 0.20);
+    --input: rgba(212, 162, 97, 0.10);
     --ring: #d4a261;
     --link: #d4a261;
-    --faint: #96866d;           /* faded latte */
+    --faint: #6a6859;
     --accent-soft: rgba(212, 162, 97, 0.10);
-    --surface-raised: #2c2218;  /* lifted mocha */
+    --surface-raised: #1f2230;
     --radius: 0.625rem;
 }
 
@@ -67,11 +67,6 @@
         @apply font-serif;
         scroll-behavior: smooth;
         background-color: var(--background);
-        /* Slightly lifted warm pools — like lamplight on the table. */
-        background-image:
-            radial-gradient(ellipse 70% 45% at 85% -8%, rgba(212, 162, 97, 0.12), transparent),
-            radial-gradient(ellipse 50% 35% at -5% 20%, rgba(212, 162, 97, 0.05), transparent);
-        background-attachment: scroll;
     }
     body {
         @apply text-foreground;


### PR DESCRIPTION
Switches the site palette from the warm coffee tones to **Ocean + caramel** — deep navy surfaces with the existing caramel accent and a slightly warm parchment foreground. The variant you picked from the local \`palette-preview.html\` comparison.

## Token changes

| Token | Before (warm coffee) | After (Ocean + caramel) |
|---|---|---|
| \`--background\` | \`#1a1612\` (espresso) | **\`#0f111a\`** (deep navy) |
| \`--foreground\` | \`#ede0c4\` (foam cream) | **\`#d8d3c2\`** (warm parchment) |
| \`--card\` | \`#241d16\` (mocha) | **\`#181a25\`** (elevated navy) |
| \`--muted-foreground\` | \`#c8b395\` (oat milk) | **\`#a8a08c\`** (warm muted) |
| \`--surface-raised\` | \`#2c2218\` (lifted mocha) | **\`#1f2230\`** |
| \`--faint\` | \`#96866d\` (faded latte) | **\`#6a6859\`** |
| \`--accent\` | \`#d4a261\` (caramel) | unchanged |

## Non-token bits

- Drop the amber radial-gradient "lamplight on the table" effect on \`<html>\` — it doesn't pair with the navy backdrop. Easy to add back in a cooler form later if the page feels flat.
- Nav background tint in \`Layout.astro\` (hardcoded for backdrop-filter math) moves from \`rgba(26,22,18,0.82)\` to \`rgba(15,17,26,0.82)\`.
- Code block in \`ArticleLayout.astro\`: bg from \`#110d09\` to \`#090b10\`; figcaption bg tint to navy; pre-code text follows the new foreground.
- Homepage entry-hover rgba normalized to the actual caramel (was the slightly more saturated old \`#d8a657\`).
- \`figure.paper img\` keeps its \`#f5efe2\` cream background intentionally — that's the "paper showing through" treatment for diagrams, palette-agnostic.

## Things I deliberately kept

- Italic Lora serif body and title
- Sans headings inside articles
- Q.E.D. page rule
- ImageLightbox, KaTeX overlays, paper-grain texture overlay (all behave fine on the new bg)

## Test plan

- [x] \`pixi run npm run build\` — 11 pages, green.
- [x] \`pixi run npm run spell\` — green.
- [ ] Preview locally with \`make dev\` — confirm the deep navy + caramel reads the way the preview did.
- [ ] Once confirmed, easy follow-ups if anything jars: re-introduce a cool gradient, adjust foreground warmth, etc.